### PR TITLE
WIP group tracks by week and year

### DIFF
--- a/app/channel/index/template.hbs
+++ b/app/channel/index/template.hbs
@@ -17,7 +17,7 @@
 	{{/if}}
 
 	{{#if tracks.isLoaded}}
-		{{#tracks-list items=tracks numbered=false as |item|}}
+		{{#tracks-list items=tracks grouped=true numbered=false as |item|}}
 			{{track-item
 				track=item
 				canEdit=canEdit

--- a/app/components/tracks-list/component.js
+++ b/app/components/tracks-list/component.js
@@ -1,12 +1,16 @@
 import Ember from 'ember';
+import groupBy from 'ember-group-by';
 
 const {Component, computed} = Ember;
 
 export default Component.extend({
 	items: null,
 	numbered: false,
+	grouped: false,
 
 	// sorts our items newest on top
 	sortKeys: ['created:desc'],
-	sortedItems: computed.sort('items', 'sortKeys')
+	sortedItems: computed.sort('items', 'sortKeys'),
+
+	itemsByMonth: groupBy('sortedItems', 'createdMonth')
 });

--- a/app/components/tracks-list/template.hbs
+++ b/app/components/tracks-list/template.hbs
@@ -1,11 +1,28 @@
-<ol class="List{{if numbered ' List--numbered'}}">
-	{{#each sortedItems as |item|}}
-		<li class="List-item">
-			{{#if hasBlock}}
-				{{yield item}}
-			{{else}}
-				{{item.title}}
-			{{/if}}
-		</li>
+{{#if grouped}}
+	{{#each itemsByMonth as |group|}}
+	<h3 class="Muted">Added {{group.value}}</h3>
+		<ol class="List{{if numbered ' List--numbered'}}">
+			{{#each group.items as |item|}}
+				<li class="List-item">
+					{{#if hasBlock}}
+						{{yield item}}
+					{{else}}
+						{{item.title}}
+					{{/if}}
+				</li>
+			{{/each}}
+		</ol>
 	{{/each}}
-</ol>
+{{else}}
+	<ol class="List{{if numbered ' List--numbered'}}">
+		{{#each sortedItems as |item|}}
+			<li class="List-item">
+				{{#if hasBlock}}
+					{{yield item}}
+				{{else}}
+					{{item.title}}
+				{{/if}}
+			</li>
+		{{/each}}
+	</ol>
+{{/if}}

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -2,9 +2,13 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import {validator, buildValidations} from 'ember-cp-validations';
 import youtubeUrlToId from 'radio4000/utils/youtube-url-to-id';
+import format from 'npm:date-fns/format';
+// import getMonth from 'npm:date-fns/get_month';
+// import getYear from 'npm:date-fns/get_year';
+// import getISOWeek from 'npm:date-fns/get_iso_week';
 
 const {Model, attr, belongsTo} = DS;
-const {get, set} = Ember;
+const {computed, get, set} = Ember;
 
 export const Validations = buildValidations({
 	url: [
@@ -33,6 +37,10 @@ export default Model.extend(Validations, {
 		defaultValue() {
 			return new Date().getTime();
 		}
+	}),
+	createdMonth: computed('created', function () {
+		let created = get(this, 'created');
+		return format(created, 'Wo \w\e\e\k of YYYY');
 	}),
 	url: attr('string'),
 	title: attr('string'),

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "stylelint-config-suitcss": "^8.0.0"
   },
   "dependencies": {
-    "date-fns": "^1.12.1",
+    "ember-date-fns": "^0.1.0",
+    "ember-group-by": "^0.0.3",
     "ember-youtube": "^0.8.0-beta.0",
     "emberfire": "^2.0.5",
     "lazysizes": "^2.0.0",


### PR DESCRIPTION
This adds a new layout to the `tracks-list` component `grouped=true`. It will group all tracks by date. For instance year, then week.

We still need to decide if we want this at all and how we want to design it.