### PR TITLE
fix/track-ended-event

### DIFF
--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -48,7 +48,7 @@
 	}
 }
 .Track--played {
-	border-right-color: $green;
+	border-right-color: $white;
 }
 .Track--finished {
 	border-right-color: $green;

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "emberfire": "^2.0.7",
     "js-cookie": "^2.1.4",
     "lazysizes": "^4.0.0-rc1",
-    "radio4000-player": "^0.1.2",
+    "radio4000-player": "^0.1.3",
     "suitcss-base": "^2.0.0",
     "torii": "^0.9.3",
     "youtube-regex": "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2567,11 +2567,7 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^1.2.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.0.tgz#00bc5b88fd23b8130f9f5049071c3420e07a5465"
-
-deepmerge@^1.3.2:
+deepmerge@^1.2.0, deepmerge@^1.3.2:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.4.4.tgz#40ef393c91af09d16a887e755337844230ad14c9"
 
@@ -6803,9 +6799,9 @@ qunitjs@^2.0.1:
     resolve "1.3.2"
     walk-sync "0.3.1"
 
-radio4000-player@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/radio4000-player/-/radio4000-player-0.1.2.tgz#d5b2ea259420a6c16cbd23bf4f31d0c4ad4da2fd"
+radio4000-player@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/radio4000-player/-/radio4000-player-0.1.3.tgz#7f6e96bb0a4ace49120622d3b9c29fb1b580f97f"
   dependencies:
     lodash.debounce "^4.0.8"
     unfetch "^3.0.0"


### PR DESCRIPTION
This PR fixes `trackEnded` event.
- track played in r4 playlist are now white border
- track finished are now green border, like before