### PR TITLE
Feature/feedback-details

### DIFF
--- a/app/components/feedback-form-google-spreadsheet/component.js
+++ b/app/components/feedback-form-google-spreadsheet/component.js
@@ -17,6 +17,7 @@ const {
 
 export default Component.extend({
 	session: inject.service(),
+	player: inject.service(),
 	flashMessages: inject.service(),
 
 	message: '',
@@ -30,6 +31,12 @@ export default Component.extend({
 	notValid: computed.empty('message'),
 	userChannelId: computed('session.currentUser.channels.firstObject.id', function () {
 		return get(this, 'session.currentUser.channels.firstObject.id') || '';
+	}),
+	playerChannelId: computed('player.currentChannel.id', function () {
+		return get(this, 'player.currentChannel.id') || '';
+	}),
+	playerTrackId: computed('player.currentTrack', function () {
+		return get(this, 'player.currentTrack.id') || '';
 	}),
 
 	clearData() {
@@ -45,7 +52,9 @@ export default Component.extend({
 			const data = {
 				message: get(this, 'message'),
 				email: get(this, 'email'),
-				userChannelId: get(this, 'userChannelId')
+				userChannelId: get(this, 'userChannelId'),
+				playerChannelId: get(this, 'playerChannelId'),
+				playerTrackId: get(this, 'playerTrackId'),
 			};
 
 			return $.ajax({

--- a/app/components/feedback-form-google-spreadsheet/component.js
+++ b/app/components/feedback-form-google-spreadsheet/component.js
@@ -54,7 +54,7 @@ export default Component.extend({
 				email: get(this, 'email'),
 				userChannelId: get(this, 'userChannelId'),
 				playerChannelId: get(this, 'playerChannelId'),
-				playerTrackId: get(this, 'playerTrackId'),
+				playerTrackId: get(this, 'playerTrackId')
 			};
 
 			return $.ajax({

--- a/app/components/x-playback/component.js
+++ b/app/components/x-playback/component.js
@@ -10,8 +10,8 @@ export default Component.extend(EKMixin, {
 	classNames: ['Playback'],
 
 	channel: computed.alias('player.currentChannel'),
-	track: computed('player.currentTrack', function () {
-		return get(this, 'player.currentTrack');
+	track: computed('player.originTrack', function () {
+		return get(this, 'player.originTrack');
 	}),
 
 	cycleFormat: on(keyUp('KeyF'), function () {

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -5,6 +5,7 @@ const {Service, inject, get, set, debug, computed} = Ember;
 export default Service.extend({
 	store: inject.service(),
 	session: inject.service(),
+	originTrack: null,
 	currentTrack: null,
 	currentChannel: computed.alias('currentTrack.channel'),
 	isPlaying: computed.bool('currentTrack'),
@@ -15,7 +16,7 @@ export default Service.extend({
 			debug('playTrack() was called without a track.');
 			return;
 		}
-		set(this, 'currentTrack', model);
+		set(this, 'originTrack', model);
 	},
 
 	onTrackChanged(event) {
@@ -33,6 +34,7 @@ export default Service.extend({
 
 		// set new track as played and active
 		get(this, 'store').findRecord('track', event.track.id).then(track => {
+			set(this, 'currentTrack', track);
 			track.setProperties({
 				playedInCurrentPlayer: true,
 				liveInCurrentPlayer: true


### PR DESCRIPTION
This PR adds:
- playerChannel and playerTrack to a feedback submission. Aim is debugg user feedback more easily with more context a request 

This PR solves:
- confusing naming of `currentTrack` in `service@player`. `currentTrack`, as in the `radio400-player` was only used as the `originTrack` (its new name), to start a playback session in `radio4000-player`.

Now the `trackChanged` event changes the `currenTrack`, when the `originTrack` is set when a user starts a new playback session.

Confusing, but what else to avoid infinite loops with r4 and r4-player to update each other state forth and back?