### PR TITLE
Expose the current DB

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -27,6 +27,10 @@ RSVP.on('error', err => {
 	Ember.assert(false, err);
 });
 
+// Expose the databaseURL so `radio4000-player` can catch it.
+window.r4 = {}
+window.r4.databaseURL = config.firebase.databaseURL
+
 loadInitializers(App, config.modulePrefix);
 
 export default App;

--- a/app/app.js
+++ b/app/app.js
@@ -28,8 +28,8 @@ RSVP.on('error', err => {
 });
 
 // Expose the databaseURL so `radio4000-player` can catch it.
-window.r4 = {}
-window.r4.databaseURL = config.firebase.databaseURL
+window.r4 = {};
+window.r4.databaseURL = config.firebase.databaseURL;
 
 loadInitializers(App, config.modulePrefix);
 


### PR DESCRIPTION
This will allow the `radio4000-player` (and potentially other parts) to know the current database URL of Radio4000.

Depends on https://github.com/internet4000/radio4000-player/pull/63