### PR TITLE
Fix edit track in Firefox

### DIFF
--- a/app/channel/tracks/track/edit/controller.js
+++ b/app/channel/tracks/track/edit/controller.js
@@ -7,12 +7,12 @@ const {
 export default Controller.extend({
 
 	actions: {
-		cancel() {
-			this.send('transitionRoute');
+		cancelAndBack() {
+			get(this, 'model').rollbackAttributes()
+			this.send('goBack')
 		},
-		transitionRoute() {
-			get(this, 'model').rollbackAttributes();
-			this.transitionToRoute('channel.tracks');
+		goBack() {
+			this.transitionToRoute('channel.tracks')
 		}
 	}
 });

--- a/app/channel/tracks/track/edit/route.js
+++ b/app/channel/tracks/track/edit/route.js
@@ -2,9 +2,4 @@ import Ember from 'ember';
 
 const {Route} = Ember;
 
-export default Route.extend({
-	model() {
-		console.log('track.edit.model', this.modelFor('channel.tracks.track'))
-		return this.modelFor('channel.tracks.track');
-	}
-});
+export default Route.extend({});

--- a/app/channel/tracks/track/edit/template.hbs
+++ b/app/channel/tracks/track/edit/template.hbs
@@ -1,7 +1,8 @@
-{{#modal-dialog close="cancel"}}
+{{#modal-dialog close="cancelAndBack"}}
 	{{track-edit
-			track=model
-			cancel=(action 'cancel')
-			transitionRoute=(action 'transitionRoute')}}
+		track=model
+		onCancel=(action 'cancelAndBack')
+		onSubmit=(action 'goBack')
+		onDelete=(action 'goBack')}}
 	{{outlet}}
 {{/modal-dialog}}

--- a/app/components/track-edit/component.js
+++ b/app/components/track-edit/component.js
@@ -7,32 +7,25 @@ const {
 	computed} = Ember;
 
 export default TrackFormComponent.extend({
-	// track model to edit
+	// Track model to edit
 	track: null,
-	// function passed as a prop
-	transitionRoute: null,
+	// Functions passed as a properties
+	onSubmit: null,
+	onDelete: null,
+
 	disableSubmit: computed.oneWay('track.validations.isInvalid'),
 
-	notify(message) {
-		const messages = get(this, 'flashMessages');
-		messages.success(message);
-	},
-
-	updateTrack: task(function * () {
+	submitTask: task(function * (event) {
+		event.preventDefault()
 		yield get(this, 'track.update').perform();
-		this.notify('Track updated');
-		yield get(this, 'transitionRoute')()
+		get(this, 'flashMessages').success('Track updated')
+		yield get(this, 'onUpdate')()
 	}).drop(),
 
-	deleteTrack: task(function * () {
+	deleteTrack: task(function * (event) {
+		event.preventDefault()
 		yield get(this, 'track.delete').perform();
-		this.notify('Track deleted');
-		yield get(this, 'transitionRoute')()
-	}).drop(),
-
-	actions: {
-		cancel() {
-			get(this, 'cancel')();
-		}
-	}
+		get(this, 'flashMessages').success('Track deleted')
+		yield get(this, 'onDelete')()
+	}).drop()
 });

--- a/app/components/track-edit/template.hbs
+++ b/app/components/track-edit/template.hbs
@@ -37,12 +37,12 @@
 	<div class="BtnGroupWrapper BtnGroupWrapper--full">
 		{{#btn-group}}
 			<button
-					onclick={{perform updateTrack}}
+					onclick={{perform submitTask}}
 					type="submit"
 					class="Btn Btn--primary"
 					title="Save the track"
-					disabled={{updateTrack.isRunning}}>
-				{{if updateTrack.isIdle "Save" "Saving…"}}
+					disabled={{submitTask.isRunning}}>
+				{{if submitTask.isIdle "Save" "Saving…"}}
 			</button>
 
 			<button {{action "cancel"}} class="Btn" title="Stop editing the track">Cancel</button>


### PR DESCRIPTION
- rename `updateTrack` to `submitTask` so it is consistent with the other track-form components
- call preventDefault (not sure why it's needed)
- remove extra `notify` abstraction