### PR TITLE
Feature/timestamps

### DIFF
--- a/app/mixins/create-track.js
+++ b/app/mixins/create-track.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import {task} from 'ember-concurrency';
-import firebase from 'firebase';
 
 const {Mixin, debug, get} = Ember;
 
@@ -32,22 +31,14 @@ export default Mixin.create({
 
 		try {
 			const tracks = yield channel.get('tracks');
-			const timestamp = firebase.database.ServerValue.TIMESTAMP;
 			tracks.addObject(track);
-			channel.set('updated', timestamp);
+			channel.set('updated', new Date());
 			yield channel.save();
 			messages.success('Your track was created', {timeout: 5000});
 		} catch (err) {
 			Ember.debug(err);
 			messages.warning('Could not save the track to your radio');
 		}
-
-		// To avoid 'updated' being NaN due to a value of {.sv: "timestamp"}
-		// we need to request an update from Firebase for the channel.
-		channel.reload();
-
-		// And we need to do a similar track for the track.
-		track.set('created', new Date().getTime());
 
 		return track;
 	}).drop()

--- a/app/models/channel.js
+++ b/app/models/channel.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import {task} from 'ember-concurrency';
 import {validator, buildValidations} from 'ember-cp-validations';
-import firebase from 'firebase';
 import channelConst from 'radio4000/utils/channel-const';
 import toggleObject from 'radio4000/utils/toggle-object';
 
@@ -57,16 +56,21 @@ export default DS.Model.extend(Validations, {
 
 	created: attr('number', {
 		defaultValue() {
-			return firebase.database.ServerValue.TIMESTAMP;
+			return new Date()
 		}
 	}),
-	updated: attr('number'),
+	updated: attr('number', {
+		defaultValue() {
+			return new Date()
+		}
+	}),
+
 	title: attr('string'),
 	slug: attr('string'),
 	body: attr('string'),
+	link: attr('string'),
 	isFeatured: attr('boolean'),
 	isPremium: attr('boolean'),
-	link: attr('string'),
 
 	// Set the latest image as the cover image.
 	coverImage: computed('images.[]', function () {

--- a/app/models/channel.js
+++ b/app/models/channel.js
@@ -54,12 +54,12 @@ export default DS.Model.extend(Validations, {
 	session: inject.service(),
 	flashMessages: inject.service(),
 
-	created: attr('number', {
+	created: attr('timestamp', {
 		defaultValue() {
 			return new Date()
 		}
 	}),
-	updated: attr('number', {
+	updated: attr('timestamp', {
 		defaultValue() {
 			return new Date()
 		}

--- a/app/models/image.js
+++ b/app/models/image.js
@@ -1,12 +1,11 @@
 import DS from 'ember-data';
-import firebase from 'firebase';
 
 const {Model, attr, belongsTo} = DS;
 
 export default Model.extend({
-	created: attr('number', {
+	created: attr('timestamp', {
 		defaultValue() {
-			return firebase.database.ServerValue.TIMESTAMP;
+			return new Date()
 		}
 	}),
 	src: attr('string'),

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -39,10 +39,6 @@ export default Model.extend(Validations, {
 			return new Date()
 		}
 	}),
-	createdMonth: computed('created', function () {
-		let created = get(this, 'created');
-		return format(created, 'MMMM YYYY');
-	}),
 	url: attr('string'),
 	title: attr('string'),
 	body: attr('string'),
@@ -59,6 +55,11 @@ export default Model.extend(Validations, {
 	liveInCurrentPlayer: false,
 	playedInCurrentPlayer: false,
 	finishedInCurrentPlayer: false,
+
+	createdMonth: computed('created', function () {
+		let created = get(this, 'created');
+		return format(created, 'MMMM YYYY');
+	}),
 
 	// If the user changes the url, we need to update the YouTube id.
 	updateYoutubeId() {

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -3,7 +3,6 @@ import DS from 'ember-data';
 import {task} from 'ember-concurrency';
 import {validator, buildValidations} from 'ember-cp-validations';
 import youtubeUrlToId from 'radio4000/utils/youtube-url-to-id';
-import firebase from 'firebase';
 import format from 'npm:date-fns/format';
 
 const {Model, attr, belongsTo} = DS;
@@ -35,9 +34,9 @@ export const Validations = buildValidations({
 });
 
 export default Model.extend(Validations, {
-	created: attr('number', {
+	created: attr('timestamp', {
 		defaultValue() {
-			return firebase.database.ServerValue.TIMESTAMP;
+			return new Date()
 		}
 	}),
 	createdMonth: computed('created', function () {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,12 +1,11 @@
 import DS from 'ember-data';
-import firebase from 'firebase';
 
 const {Model, attr, belongsTo, hasMany} = DS;
 
 export default Model.extend({
-	created: attr('number', {
+	created: attr('timestamp', {
 		defaultValue() {
-			return firebase.database.ServerValue.TIMESTAMP;
+			return new Date()
 		}
 	}),
 	channels: hasMany('channel', {

--- a/app/timestamp/transform.js
+++ b/app/timestamp/transform.js
@@ -1,0 +1,11 @@
+// Copy/paste from
+// https://github.com/rmmmp/emberfire-utils/blob/master/addon/transforms/timestamp.js
+
+import Transform from 'ember-data/transforms/date'
+import firebase from 'firebase'
+
+export default Transform.extend({
+	serialize() {
+		return firebase.database.ServerValue.TIMESTAMP
+	}
+})

--- a/tests/unit/timestamp/transform-test.js
+++ b/tests/unit/timestamp/transform-test.js
@@ -1,0 +1,33 @@
+// Copy/pasted from
+// https://github.com/rmmmp/emberfire-utils/blob/master/tests/unit/transforms/timestamp-test.js
+
+import { moduleFor, test } from 'ember-qunit';
+import firebase from 'firebase';
+
+moduleFor('transform:timestamp', 'Unit | Transform | timestamp');
+
+test('should serialize to Firebase server value timestamp', function(assert) {
+  assert.expect(1);
+
+  // Arrange
+  const transform = this.subject();
+
+  // Act
+  const result = transform.serialize();
+
+  // Assert
+  assert.deepEqual(result, firebase.database.ServerValue.TIMESTAMP);
+});
+
+test('should deserialize to date', function(assert) {
+  assert.expect(1);
+
+  // Arrange
+  const transform = this.subject();
+
+  // Act
+  const result = transform.deserialize(1483228800000);
+
+  // Assert
+  assert.deepEqual(result, new Date('2017-01-01'));
+});


### PR DESCRIPTION
This is an attempt to streamline the way we handle dates and timestamps on our models with Firebase. We rely on Firebase to set the server timestamp in the backend. This means setting the value of a `model.created` to `{.sv: "timestamp"}`. Firebase will then set the right timestamp.

But this leaves the front-end with a weird object as date which it doesn't understand. SO, https://github.com/rmmmp/emberfire-utils provides a `timestamp` transform to solve this.

1. new custom `timestamp` transform
2. Set our date fields in models to `DS.attr('timestamp')`
3. Set dates with `new Date()` or `new Date.getTime()` - both work
4. When saving the model, the transform will serialize it to the firebase timestamp

For this to work on Radio4000, we need to update our rules. This seems to work but I'd like feedback here, too.

```
"created": {
  // Ensure that you can not update the original value
  ".validate": "data.exists() && data.val() === newData.val() || newData.val() >= now"
},
"updated": {
  ".write": "newData.val() >= now"
},
``` 

Requires https://github.com/internet4000/radio4000-api/pull/27 to be merged
Closes https://github.com/internet4000/radio4000/issues/73