### PR TITLE
Feature/improve channel index

### DIFF
--- a/app/channel/index/controller.js
+++ b/app/channel/index/controller.js
@@ -4,8 +4,8 @@ const {
 	Controller,
 	computed,
 	inject,
-	get,
-	debug} = Ember;
+	get
+} = Ember;
 
 export default Controller.extend({
 	applicationController: inject.controller('application'),
@@ -15,8 +15,6 @@ export default Controller.extend({
 
 	actions: {
 		addTrack(url) {
-			debug(`Trying to add ${url}`);
-
 			// Setting these properties open a modal in the application template.
 			get(this, 'applicationController').setProperties({
 				newUrl: url,

--- a/app/channel/index/template.hbs
+++ b/app/channel/index/template.hbs
@@ -20,7 +20,7 @@
 
 			{{#if latestTracks}}
 				{{#tracks-list items=latestTracks as |item|}}
-					{{track-item track=item}}
+					{{track-item track=item inline=true}}
 				{{/tracks-list}}
 			{{else}}
 				{{#is-loading}}

--- a/app/channel/tracks/track/edit/template.hbs
+++ b/app/channel/tracks/track/edit/template.hbs
@@ -1,4 +1,4 @@
-{{#modal-dialog close="cancelAndBack"}}
+{{#modal-dialog onClose=(action "cancelAndBack")}}
 	{{track-edit
 		track=model
 		onCancel=(action 'cancelAndBack')

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -21,7 +21,7 @@
 </aside>
 
 {{#if isShowingModal}}
-	{{#modal-dialog close="toggleModal" translucentOverlay=true}}
+	{{#modal-dialog onClose=(action "toggleModal")}}
 		<div class="Manchet">
 			<h2><small>Add a </small>new track<small> to your radio</small></h2>
 		</div>

--- a/app/components/modal-dialog/component.js
+++ b/app/components/modal-dialog/component.js
@@ -1,21 +1,16 @@
 import Ember from 'ember';
 import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
-// import {EKOnFocusMixin, keyUp} from 'ember-keyboard';
 
 const {on, $} = Ember;
 
 export default ModalDialog.extend({
+	// Change the default value to use overlay.
 	translucentOverlay: true,
-	overlayClassNames: ['ember-modal-overlay'],
-
-	// activateKeyboard: Ember.on('init', function () {
-	// 	this.set('keyboardActivated', true);
-	// }),
-	// onEscape: on(keyUp('Escape'), function () {
-	// 	this.sendAction('close');
-	// })
 
 	setup: on('didInsertElement', function () {
+		this._super()
+
+		// Close modal on ESC.
 		$('body').on('keyup.modal-dialog', e => {
 			if (e.keyCode === 27) {
 				this.sendAction('close');

--- a/app/components/track-edit/template.hbs
+++ b/app/components/track-edit/template.hbs
@@ -45,7 +45,7 @@
 				{{if submitTask.isIdle "Save" "Saving…"}}
 			</button>
 
-			<button {{action "cancel"}} class="Btn" title="Stop editing the track">Cancel</button>
+			<button {{action "cancel"}} class="Btn Btn--text" title="Stop editing the track">Cancel</button>
 		{{/btn-group}}
 		{{#btn-group class="BtnGroup--right"}}
 			<button

--- a/app/components/track-form/component.js
+++ b/app/components/track-form/component.js
@@ -73,6 +73,7 @@ export default Component.extend({
 			get(this, 'submitTask').perform();
 		},
 		cancel() {
+			get(this, 'track').rollbackAttributes();
 			get(this, 'onCancel')();
 		}
 	}

--- a/app/components/track-item/component.js
+++ b/app/components/track-item/component.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {Component, computed, inject} = Ember;
+const {Component, computed, get, set, inject} = Ember;
 
 export default Component.extend({
 	player: inject.service(),
@@ -21,10 +21,16 @@ export default Component.extend({
 
 	actions: {
 		edit() {
-			this.get('edit')(this.get('track'));
+			this.toggleProperty('isEditing')
 		},
 		play(track) {
-			this.set('player.model', track);
+			get(this, 'player').playTrack(track)
+		},
+		goBack(rollback) {
+			if (rollback) {
+				get(this, 'track').rollbackAttributes()
+			}
+			set(this, 'isEditing', false)
 		}
 	}
 });

--- a/app/components/track-item/template.hbs
+++ b/app/components/track-item/template.hbs
@@ -36,4 +36,4 @@
 	</div>
 {{/if}}
 
-{{outlet}}
+{{yield}}

--- a/app/components/track-item/template.hbs
+++ b/app/components/track-item/template.hbs
@@ -1,12 +1,39 @@
-{{#link-to 'channel.tracks.track.index' track class="Track-link"}}
-	<h3 class="Track-title">
-		{{track.title}}
-	</h3>
-	<p class="Track-body">{{track.body}}</p>
-{{/link-to}}
+{{#if inline}}
+	<a href="#" {{action "play" track}}>
+		<h3 class="Track-title">
+			{{track.title}}
+		</h3>
+		<p class="Track-body">{{track.body}}</p>
+	</a>
+{{else}}
+	{{#link-to 'channel.tracks.track.index' track class="Track-link"}}
+		<h3 class="Track-title">
+			{{track.title}}
+		</h3>
+		<p class="Track-body">{{track.body}}</p>
+	{{/link-to}}
+{{/if}}
 
 {{#if track.channel.canEdit}}
-	{{link-to 'Edit' 'channel.tracks.track.edit' track
+	{{#if inline}}
+		<button class="Track-controls Muted" {{action "edit"}}>Edit</button>
+	{{else}}
+		{{link-to 'Edit' 'channel.tracks.track.edit' track
 			class="Btn Btn--text Muted Track-controls"
 			title="Edit the track"}}
+	{{/if}}
 {{/if}}
+
+{{#if isEditing}}
+	<div class="Track-modal">
+		{{#modal-dialog onClose=(action "goBack" true)}}
+			{{track-edit
+				track=track
+				onCancel=(action "goBack" true)
+				onSubmit=(action "goBack")
+				onDelete=(action "goBack")}}
+		{{/modal-dialog}}
+	</div>
+{{/if}}
+
+{{outlet}}

--- a/app/styles/components/_modal-dialog.scss
+++ b/app/styles/components/_modal-dialog.scss
@@ -15,6 +15,6 @@
 }
 
 // Set background for ember-modals
-.ember-modal-overlay.translucent {
-	background-color: hsla(0, 0%, 17%, 0.3);
+div.ember-modal-overlay.translucent {
+	background-color: hsla(0, 0%, 20%, 0.1);
 }

--- a/app/styles/components/_modal-dialog.scss
+++ b/app/styles/components/_modal-dialog.scss
@@ -1,16 +1,14 @@
 // Modals using the ember-modal-dialog addon.
 
 .ember-modal-dialog {
-	padding: 2.4rem 2rem 0.5rem;
+	padding: 2.4rem 2rem 0;
+	box-shadow: $box-shadow;
+	border: 1px solid $mediumlightgray;
 	border-radius: $border-radius;
-	box-shadow: -4px 4px 12px rgba(88, 88, 88, 0.25);
 
-	// forms inside modals
 	.Form {
-		max-width: 100%;
-		margin-bottom: 0;
-
 		@media (min-width: 520px) {
+			// Sets the width of the modal.
 			width: 500px;
 		}
 	}
@@ -18,5 +16,5 @@
 
 // Set background for ember-modals
 .ember-modal-overlay.translucent {
-	background-color: rgba(43, 43, 43, 0.24);
+	background-color: hsla(0, 0%, 17%, 0.3);
 }

--- a/app/styles/components/_modal-dialog.scss
+++ b/app/styles/components/_modal-dialog.scss
@@ -5,13 +5,8 @@
 	box-shadow: $box-shadow;
 	border: 1px solid $mediumlightgray;
 	border-radius: $border-radius;
-
-	.Form {
-		@media (min-width: 520px) {
-			// Sets the width of the modal.
-			width: 500px;
-		}
-	}
+	width: calc(100% - 2rem);
+	max-width: 500px;
 }
 
 // Set background for ember-modals

--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -103,6 +103,7 @@ a.Track-link {
 
 // Track edit button.
 .Track-controls {
+	@include size-0;
 	position: absolute;
 	top: 0;
 	right: 0;

--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -106,7 +106,13 @@ a.Track-link {
 	position: absolute;
 	top: 0;
 	right: 0;
-	bottom: 0;
-	padding: 0.75rem 1.5rem em(3, 13) 0.5rem;
-	margin: 0;
+	padding: 1rem 1.5rem 1rem 0.5rem;
+}
+
+.Track .Form {
+	margin: 0 1rem 0 2rem;
+
+	h2 {
+		display: none;
+	}
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-keyboard": "^2.1.10",
     "ember-load-initializers": "^1.0.0",
-    "ember-modal-dialog": "^1.0.0",
+    "ember-modal-dialog": "^2.3.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "^2.15.0",
     "eslint-config-xo": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,7 +2916,7 @@ ember-cli-babel@5.1.6:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -3018,7 +3018,7 @@ ember-cli-htmlbars-inline-precompile@^0.4.0:
     hash-for-dep "^1.0.2"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.0.8, ember-cli-htmlbars@^1.1.1, ember-cli-htmlbars@^1.3.2:
+ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1, ember-cli-htmlbars@^1.3.2:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz#461289724b34af372a6a0c4b6635819156963353"
   dependencies:
@@ -3027,6 +3027,15 @@ ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.0.8,
     hash-for-dep "^1.0.2"
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
+
+ember-cli-htmlbars@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz#e116e1500dba12f29c94b05b9ec90f52cb8bb042"
+  dependencies:
+    broccoli-persistent-filter "^1.0.3"
+    hash-for-dep "^1.0.2"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^3.0.0"
 
 ember-cli-inject-live-reload@^1.4.1:
   version "1.7.0"
@@ -3358,6 +3367,12 @@ ember-href-to@^1.12.1:
   dependencies:
     ember-cli-babel "^5.1.6"
 
+ember-ignore-children-helper@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-ignore-children-helper/-/ember-ignore-children-helper-1.0.0.tgz#7645d769377779ff292235725b5b1f5c2e4c16ab"
+  dependencies:
+    ember-cli-babel "^5.1.6"
+
 ember-inflector@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.0.1.tgz#e9ac469ffa17992a43276bb1c9b8d87992b10d37"
@@ -3391,14 +3406,14 @@ ember-maybe-import-regenerator@^0.1.5:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-modal-dialog@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-modal-dialog/-/ember-modal-dialog-1.0.0.tgz#829f083cb4a4162dd2a5158e3980123b7cb69328"
+ember-modal-dialog@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/ember-modal-dialog/-/ember-modal-dialog-2.3.0.tgz#7adf8e19f225ad637e8d4de5a7f69262149e2066"
   dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-htmlbars "^1.0.8"
-    ember-cli-version-checker "^1.2.0"
-    ember-wormhole "~0.3.6"
+    ember-cli-babel "^6.1.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-ignore-children-helper "^1.0.0"
+    ember-wormhole "^0.5.1"
 
 ember-qunit@^2.1.3:
   version "2.2.0"
@@ -3520,11 +3535,12 @@ ember-validators@1.0.3:
     ember-cli-babel "^5.1.6"
     ember-require-module "^0.1.2"
 
-ember-wormhole@~0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.3.6.tgz#bbe21bb5478ad254efe4fff4019ac6710f4ad85c"
+ember-wormhole@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.2.tgz#cc0ceb7db4f8b8da0fd852edc81d75cb1dcd92f1"
   dependencies:
-    ember-cli-babel "^5.0.0"
+    ember-cli-babel "^6.0.0"
+    ember-cli-htmlbars "^1.1.1"
 
 emberfire@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
This is an attempt to solve the UX for editing and playing tracks from our new "latest tracks" section.

Now, clicking a track will play it without changing route. Clicking edit will open a modal on the same route.

Dev notes: Setting `{{track-item inline=true}}`enables this behaviour.

Closes #88 