### PR TITLE
Feature/oembed

### DIFF
--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -2,9 +2,10 @@
 /* global document, window */
 import Ember from 'ember';
 
-const {Route} = Ember;
+const {Route, get, set, inject} = Ember;
 
 export default Route.extend({
+	headData: inject.service(),
 	model(params) {
 		return this.store.query('channel', {
 			orderBy: 'slug',
@@ -12,11 +13,11 @@ export default Route.extend({
 		}).then(data => data.get('firstObject'));
 	},
 	afterModel(model) {
-		if (model) {
-			document.title = `${model.get('title')} - Radio4000`;
-		} else {
+		if (!model) {
 			this.transitionTo('404');
+			return
 		}
+		this.setHeadData(model)
 	},
 	serialize(model) {
 		return {channel_slug: model.get('slug')};
@@ -25,7 +26,26 @@ export default Route.extend({
 		window.scrollTo(0, 0);
 	},
 	deactivate() {
-		// Reset doc title when leaving the route
-		document.title = 'Radio4000';
+		// Reset meta tags when leaving the route.
+		get(this, 'headData').setProperties({
+			title: null, description: null, image: null
+		})
+	},
+	setHeadData(model) {
+		const headData = get(this, 'headData')
+		const title = `${model.get('title')} - Radio4000`;
+		const body = model.get('body')
+
+		set(headData, 'title', title)
+		if (body) {
+			set(headData, 'description', body)
+		}
+		// `model.get('coverImage.src')` doesn't seem to work
+		model.get('images').then(images => {
+			const src = images.get('lastObject.src')
+			if (src) {
+				set(headData, 'image', src)
+			}
+		})
 	}
 });

--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -33,7 +33,8 @@ export default Route.extend({
 	},
 	setHeadData(model) {
 		const headData = get(this, 'headData')
-		const title = `${model.get('title')} - Radio4000`;
+		// const title = `${model.get('title')} - Radio4000`;
+		const title = model.get('title')
 		const body = model.get('body')
 
 		set(headData, 'title', title)

--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -28,16 +28,17 @@ export default Route.extend({
 	deactivate() {
 		// Reset meta tags when leaving the route.
 		get(this, 'headData').setProperties({
-			title: null, description: null, image: null
+			title: null, description: null, image: null, slug: null
 		})
 	},
 	setHeadData(model) {
 		const headData = get(this, 'headData')
 		// const title = `${model.get('title')} - Radio4000`;
 		const title = model.get('title')
+		const slug = model.get('slug')
 		const body = model.get('body')
-
 		set(headData, 'title', title)
+		set(headData, 'slug', slug)
 		if (body) {
 			set(headData, 'description', body)
 		}

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
-	<title>Radio4000</title>
+	<!-- <title>Radio4000</title> -->
 	<meta name="description" content="Collect, curate, play and share your own radio channel">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
 	<meta name="mobile-web-app-capable" content="yes" />

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
-	<!-- <title>Radio4000</title> -->
+	<title>Radio4000</title>
 	<meta name="description" content="Collect, curate, play and share your own radio channel">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
 	<meta name="mobile-web-app-capable" content="yes" />
@@ -11,7 +11,7 @@
 	<link rel="icon" href="/favicon-192x192.png" sizes="192x192">
 	<link rel="manifest" href="/manifest.json">
 	<meta name="theme-color" content="#5d1ae6">
-	<meta name="og:image" content="https://radio4000.com/assets/images/logos/radio4000-square.png">
+	<meta name="og:image" content="https://assets.radio4000.com/icon.png">
 	{{content-for "head"}}
 	<link rel="preload" as="font" href="https://res.cloudinary.com/radio4000/raw/upload/v1492541388/maisonneueweb-book_ee98sm.woff2" type="font/woff2" crossorigin />
 	<link rel="preload" as="font" href="https://res.cloudinary.com/radio4000/raw/upload/v1492541388/maisonneueweb-bold_rvmbzr.woff2" type="font/woff2" crossorigin />

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,20 @@
+{{!-- 
+  Add content you wish automatically added to the documents head
+  here. The 'model' available in this template can be populated by
+  setting values on the 'head-data' service. 
+--}}
+
+{{#if model.title}}
+	<meta property="og:title" content={{model.title}}>
+	<title>{{model.title}}</title>
+{{else}}
+	<title>Radio4000</title>
+{{/if}}
+
+{{#if model.description}}
+	<meta property="og:description" content={{model.description}}>
+{{/if}}
+
+{{#if model.image}}
+	<meta property="og:image" content={{cover-img model.image format="jpg" size=400}}>
+{{/if}}

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -18,3 +18,9 @@
 {{#if model.image}}
 	<meta property="og:image" content={{cover-img model.image format="jpg" size=400}}>
 {{/if}}
+
+{{#if model.slug}}
+	<link rel="alternate" type="application/json+oembed"
+  href={{concat "https://api.radio4000.com/oembed?slug=" model.slug}}
+  title={{concat model.title "'s oEmbed profile"}}>	
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ember-cli-eslint": "^3.1.0",
     "ember-cli-flash": "^1.4.2",
     "ember-cli-google-analytics": "^1.5.0",
+    "ember-cli-head": "^0.3.1",
     "ember-cli-htmlbars": "^1.3.2",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,6 +3009,13 @@ ember-cli-google-analytics@^1.5.0:
   dependencies:
     lodash-node "^2.4.1"
 
+ember-cli-head@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-head/-/ember-cli-head-0.3.1.tgz#a407df4880f235280371c437bb5b0b5cbdaea646"
+  dependencies:
+    ember-cli-babel "^6.1.0"
+    ember-cli-htmlbars "^2.0.1"
+
 ember-cli-htmlbars-inline-precompile@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.4.4.tgz#24a7617152630d64a047e553b72e00963a4f8d73"


### PR DESCRIPTION
Adds og:title/description/image tags for channels as well as an oembed link to our API.

![oembed](https://user-images.githubusercontent.com/184567/30500320-0d6c9c8a-9a5e-11e7-9ef5-c3b8df06ad5e.png)

I'm not sure the computers that parse these tags understand JavaScript. If not, we need prerendering for it to have any effect.

- [ ] Check if it gets picked up on Twitter, Facebook, Slack 
- [ ] Consider if other routes need meta tags

Test URL: https://feature-oembed--radio4000.netlify.com/imperium

- https://cards-dev.twitter.com/validator
- https://developers.facebook.com/tools/debug/

Does netlify offer prerendering for branches? Is it cached? Many questions.