### PR TITLE
Upgrade radio4000-player

### DIFF
--- a/app/styles/components/_playback-external.scss
+++ b/app/styles/components/_playback-external.scss
@@ -1,9 +1,13 @@
 /**
  * PlaybackExternal
  */
+
 // .PlaybackExternal {}
-.PlaybackExternal-action {
-	&:hover {
-		cursor: pointer;
-	}
+
+.PlaybackExternal-action:hover {
+	cursor: pointer;
+}
+
+radio4000-player .Btn {
+	min-height: initial;
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "emberfire": "^2.0.8",
     "js-cookie": "^2.1.4",
     "lazysizes": "^4.0.0-rc1",
-    "radio4000-player": "^0.2.0",
+    "radio4000-player": "^0.3.0",
     "suitcss-base": "^3.0.0",
     "torii": "^0.9.3",
     "youtube-regex": "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,9 +2282,15 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.6, debug@^2.6.8, debug@~2.6.7:
+debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.6.6:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -2300,7 +2306,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^1.2.0, deepmerge@^1.3.2:
+deepmerge@^1.2.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+
+deepmerge@^1.3.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.0.tgz#00bc5b88fd23b8130f9f5049071c3420e07a5465"
 
@@ -2481,8 +2491,8 @@ electron-to-chromium@^1.3.17:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz#41c13457cc7166c5c15e767ae61d86a8cacdee5d"
 
 element-ui@^1.3.6:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-1.4.1.tgz#f4471cadb43dc779c3098dc73634aea94d03f255"
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-1.4.6.tgz#2f4f718fb3b12f23ef6508251adfae80d7f81793"
   dependencies:
     async-validator "1.6.9"
     babel-helper-vue-jsx-merge-props "^2.0.0"
@@ -5856,8 +5866,8 @@ printf@^0.2.3:
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
 
 prismjs@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.6.0.tgz#118d95fb7a66dba2272e343b345f5236659db365"
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.8.1.tgz#bd0cdc32e9a561c1c8c3c9733765a7f1ec3b54ee"
   optionalDependencies:
     clipboard "^1.5.5"
 
@@ -5974,9 +5984,9 @@ qunitjs@^2.0.1:
     resolve "1.3.2"
     walk-sync "0.3.1"
 
-radio4000-player@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/radio4000-player/-/radio4000-player-0.2.0.tgz#983fffddfee89a4d85da876ec3fce82f190081d5"
+radio4000-player@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/radio4000-player/-/radio4000-player-0.3.0.tgz#a7c5e5d622a5064bc28c458159c20ad2e67013d1"
   dependencies:
     lodash.debounce "^4.0.8"
     unfetch "^3.0.0"
@@ -7047,8 +7057,8 @@ timers-browserify@^2.0.2:
     setimmediate "^1.0.4"
 
 tiny-emitter@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.1.tgz#e65919d91e488e2a78f7ebe827a56c6b188d51af"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
 tiny-lr@^1.0.3:
   version "1.0.5"
@@ -7324,12 +7334,12 @@ vue-custom-element@^1.1.0:
     vue-router "^2.5.3"
 
 vue-router@^2.5.3:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-2.7.0.tgz#16d424493aa51c3c8cce8b7c7210ea4c3a89aff1"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-2.8.0.tgz#69df774c512112cd13e4748588861e27e0d0a9bc"
 
 vue@^2.3.4, vue@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.2.tgz#a9855261f191c978cc0dc1150531b8d08149b58c"
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.4.tgz#ea9550b96a71465fd2b8b17b61673b3561861789"
 
 walk-sync@0.3.1:
   version "0.3.1"


### PR DESCRIPTION
Upgrades the player. Since we don't yet use shadowdom our radio4000 styles from `.Btn` are conflicting with player styles. I added a quick fix but some day we should rethink this.