### PR TITLE
Add loading template for channel/tracks

### DIFF
--- a/app/channel/loading/template.hbs
+++ b/app/channel/loading/template.hbs
@@ -1,0 +1,3 @@
+<div class="Container">
+	<p>Loading channel…</p>
+</div>


### PR DESCRIPTION
This way, when you tap "tracks" it transitions immediately to the loading route, then shows tracks.

Before it would "lock up" until all tracks are loaded, then transition. Please test it to see how it feels when navigate between tabs on the `channel` route.