### PR TITLE
Feature/repost track

### DIFF
--- a/app/add/template.hbs
+++ b/app/add/template.hbs
@@ -21,9 +21,9 @@
 	<section class="Section">
 		<div class="Container Container--full">
 			<div class="Grid">
-				<div class="Grid-cell">
+				<div class="Grid-cell Grid-cell--double">
 					<p>You are adding to:</p>
-					{{channel-card channel=model}}
+					{{channel-card channel=model wide=true}}
 				</div>
 				<div class="Muted Grid-cell">
 					<p>

--- a/app/add/template.hbs
+++ b/app/add/template.hbs
@@ -8,7 +8,8 @@
 					initialUrl=url
 					onSubmit=(action "saveTrack")
 					onCancel=(action "goBack")
-					isSubmitting=createTrack.isRunning}}
+					isSubmitting=createTrack.isRunning
+					session=session}}
 			{{#unless model.tracks}}
 				<p class="Muted">
 					Tip: you are adding your first track.

--- a/app/add/template.hbs
+++ b/app/add/template.hbs
@@ -13,7 +13,7 @@
 				<p class="Muted">
 					Tip: you are adding your first track.
 					Copy this link <a href="https://www.youtube.com/watch?v=5EH5GFP2Otk">https://www.youtube.com/watch?v=5EH5GFP2Otk</a>
-					and paste it the the <strong>URL</strong> field bellow.
+					and paste it the the <strong>URL</strong> field above.
 				</p>
 			{{/unless}}
 		</div>

--- a/app/add/template.hbs
+++ b/app/add/template.hbs
@@ -5,11 +5,10 @@
 		</div>
 		<div class="Container">
 			{{track-form-add
-					initialUrl=url
-					onSubmit=(action "saveTrack")
-					onCancel=(action "goBack")
-					isSubmitting=createTrack.isRunning
-					session=session}}
+				initialUrl=url
+				onSubmit=(action "saveTrack")
+				onCancel=(action "goBack")
+				isSubmitting=createTrack.isRunning}}
 			{{#unless model.tracks}}
 				<p class="Muted">
 					Tip: you are adding your first track.

--- a/app/add/template.hbs
+++ b/app/add/template.hbs
@@ -9,6 +9,13 @@
 					onSubmit=(action "saveTrack")
 					onCancel=(action "goBack")
 					isSubmitting=createTrack.isRunning}}
+			{{#unless model.tracks}}
+				<p class="Muted">
+					Tip: you are adding your first track.
+					Copy this link <a href="https://www.youtube.com/watch?v=5EH5GFP2Otk">https://www.youtube.com/watch?v=5EH5GFP2Otk</a>
+					and paste it the the <strong>URL</strong> field bellow.
+				</p>
+			{{/unless}}
 		</div>
 	</div>
 	<section class="Section">
@@ -18,9 +25,9 @@
 					<p>You are adding to:</p>
 					{{channel-card channel=model}}
 				</div>
-				<div class="Grid-cell">
+				<div class="Muted Grid-cell">
 					<p>
-						Want to add tracks faster to your Radio4000 channel?
+						Tip: do you want to <strong>add tracks faster</strong> into your Radio4000 channel?
 					</p>
 					<p>
 						{{link-to "Get the bookmarklet" "bookmarklet" class="Btn"}}

--- a/app/channel/favorites/template.hbs
+++ b/app/channel/favorites/template.hbs
@@ -63,7 +63,7 @@
 	</section>
 
 	{{else}}
-	<div class="Container">
+	<div class="Container Muted">
 		<p>This radio doesn't have any favorites, yet.</p>
 	</div>
 {{/if}}

--- a/app/channel/index/template.hbs
+++ b/app/channel/index/template.hbs
@@ -11,14 +11,14 @@
 				Latest tracks
 				<small>({{link-to "see all" "channel.tracks"}})</small>
 			</h3>
-		</div>
-		<div class="Container Container--noPaddingMobile">
 
 			{{#if model.channel.canEdit}}
 				<form class="Form">
 					{{track-add-inline onSubmit=(action "addTrack")}}
 				</form>
 			{{/if}}
+		</div>
+		<div class="Container Container--noPaddingMobile">
 
 			{{#if model.latestTracks}}
 				{{#tracks-list items=model.latestTracks as |item|}}

--- a/app/channel/tracks/route.js
+++ b/app/channel/tracks/route.js
@@ -1,12 +1,17 @@
 import Ember from 'ember';
 import ResetScroll from 'radio4000/mixins/reset-scroll'
 
-export default Ember.Route.extend(ResetScroll, {
+const {Route, RSVP} = Ember
+
+export default Route.extend(ResetScroll, {
 	model() {
 		const channel = this.modelFor('channel')
-		return this.store.query('track', {
-			orderBy: 'channel',
-			equalTo: channel.id
-		})
+		return RSVP.hash({
+			channel,
+			tracks: this.store.query('track', {
+				orderBy: 'channel',
+				equalTo: channel.id
+			})
+		});
 	}
 });

--- a/app/channel/tracks/template.hbs
+++ b/app/channel/tracks/template.hbs
@@ -1,22 +1,21 @@
 <section class="Section">
 	<div class="Container Container--noPaddingMobile">
-		{{#if model.isLoaded}}
+		{{#if model.tracks.isLoaded}}
 			{{#tracks-list
-					 items=model
+					 items=model.tracks
 					 grouped=true
 					 numbered=false as |item|}}
 				{{track-item track=item}}
 			{{/tracks-list}}
 
-			{{#unless model.length}}
-				{{#if model.canEdit}}
-					<p>
-						Your radio has no tracks yet.<br>
-						Try to {{link-to 'add your first' 'add'}}.
+			{{#unless model.tracks.length}}
+					<p class="Muted">
+						{{#if model.channel.canEdit}}
+							Your radio has no tracks yet. Try to {{link-to 'add your first' 'add'}}.
+						{{else}}
+							This radio has no tracks yet.
+						{{/if}}
 					</p>
-				{{else}}
-					<p>This radio has no tracks yet.</p>
-				{{/if}}
 			{{/unless}}
 		{{else}}
 			{{#is-loading}}

--- a/app/channel/tracks/template.hbs
+++ b/app/channel/tracks/template.hbs
@@ -2,7 +2,7 @@
 	<div class="Container Container--noPaddingMobile">
 		{{#if model.tracks.isLoaded}}
 			{{#tracks-list
-				items=model
+				items=model.tracks
 				grouped=true
 				numbered=false as |item|}}
 				{{track-item track=item}}

--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -1,7 +1,7 @@
 /* global document */
 import Ember from 'ember';
 
-const {Component, inject, run} = Ember;
+const {Component, inject, run, get, set} = Ember;
 
 export default Component.extend({
 	uiStates: inject.service(),
@@ -33,12 +33,20 @@ export default Component.extend({
 	},
 
 	actions: {
-		toggleModal() {
-			this.toggleProperty('isShowingModal');
-			this.set('url', '');
+		openAddTrack(track) {
+			console.log(track)
+			if(track) {
+				set(this, 'url', track.url);
+			} else {
+				set(this, 'url', '');
+			}
+			set(this, 'isShowingModal', true);
+		},
+		closeModal() {
+			set(this, 'isShowingModal', false);
 		},
 		saveTrack(trackProperties) {
-			return this.get('onSaveTrack')(trackProperties);
+			return get(this, 'onSaveTrack')(trackProperties);
 		}
 	}
 });

--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -34,11 +34,8 @@ export default Component.extend({
 
 	actions: {
 		openAddTrack(track) {
-			console.log('@appRoot:openAddTrack: no track', track)
 			if (track) {
-				set(this, 'url', track.url);
-			} else {
-				set(this, 'url', '');
+				set(this, 'url', track.url || '');
 			}
 			set(this, 'isShowingModal', true);
 		},

--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -34,8 +34,8 @@ export default Component.extend({
 
 	actions: {
 		openAddTrack(track) {
-			console.log(track)
-			if(track) {
+			console.log('@appRoot:openAddTrack: no track', track)
+			if (track) {
 				set(this, 'url', track.url);
 			} else {
 				set(this, 'url', '');

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -12,7 +12,6 @@
 	onClick=(action "openAddTrack")}}
 
 <main class="SiteMain">
-	{{play-random-channel keyboardActivated=true}}
 	{{yield}}
 </main>
 

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -28,7 +28,6 @@
 				</div>
 				<p class="Container">
 					{{track-form-add
-						session=session
 						initialUrl=url
 						onSubmit=(action "saveTrack")
 						onCancel=(action "closeModal")}}

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -37,7 +37,6 @@
 				<p class="Container">
 					<span class="Muted" {{action "closeModal"}}>{{link-to "Add faster with the Bookmarklet" "bookmarklet"}}</span>
 				</p>
-
 			</section>
 		</div>
 	{{/modal-dialog}}

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -27,16 +27,16 @@
 				<div class="Manchet">
 					<h2><small>Add a </small>new track<small> to your radio</small></h2>
 				</div>
-				<div class="Container">
+				<p class="Container">
 					{{track-form-add
 							initialUrl=url
 							onSubmit=(action "saveTrack")
 							onCancel=(action "closeModal")}}
-					<div>
-						Do you want to add tracks directly from YouTube?<br>
-						&rarr;<span {{action "closeModal"}}>{{link-to "Get the bookmarklet" "bookmarklet" class="Btn Btn--text"}}</span>
-					</div>
-				</div>
+				</p>
+				<p class="Container">
+					<span class="Muted" {{action "closeModal"}}>{{link-to "Add faster with the Bookmarklet" "bookmarklet"}}</span>
+				</p>
+
 			</section>
 		</div>
 	{{/modal-dialog}}

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -9,7 +9,7 @@
 {{aside-left
 		isAuthenticated=session.isAuthenticated
 		userChannel=session.currentUser.channels.firstObject
-		toggleModal=(action "toggleModal")}}
+		onClick=(action "openAddTrack")}}
 
 <main class="SiteMain">
 	{{play-random-channel keyboardActivated=true}}
@@ -21,7 +21,7 @@
 </aside>
 
 {{#if isShowingModal}}
-	{{#modal-dialog onClose=(action "toggleModal")}}
+	{{#modal-dialog onClose=(action "closeModal")}}
 		<div class="Sections">
 			<section class="Section">
 				<div class="Manchet">
@@ -31,10 +31,10 @@
 					{{track-form-add
 							initialUrl=url
 							onSubmit=(action "saveTrack")
-							onCancel=(action "toggleModal")}}
+							onCancel=(action "closeModal")}}
 					<div>
 						Do you want to add tracks directly from YouTube?<br>
-						&rarr;<span {{action "toggleModal"}}>{{link-to "Get the bookmarklet" "bookmarklet" class="Btn Btn--text"}}</span>
+						&rarr;<span {{action "closeModal"}}>{{link-to "Get the bookmarklet" "bookmarklet" class="Btn Btn--text"}}</span>
 					</div>
 				</div>
 			</section>

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -7,9 +7,9 @@
 {{/if}}
 
 {{aside-left
-		isAuthenticated=session.isAuthenticated
-		userChannel=session.currentUser.channels.firstObject
-		onClick=(action "openAddTrack")}}
+	isAuthenticated=session.isAuthenticated
+	userChannel=session.currentUser.channels.firstObject
+	onClick=(action "openAddTrack")}}
 
 <main class="SiteMain">
 	{{play-random-channel keyboardActivated=true}}
@@ -29,9 +29,10 @@
 				</div>
 				<p class="Container">
 					{{track-form-add
-							initialUrl=url
-							onSubmit=(action "saveTrack")
-							onCancel=(action "closeModal")}}
+						session=session
+						initialUrl=url
+						onSubmit=(action "saveTrack")
+						onCancel=(action "closeModal")}}
 				</p>
 				<p class="Container">
 					<span class="Muted" {{action "closeModal"}}>{{link-to "Add faster with the Bookmarklet" "bookmarklet"}}</span>

--- a/app/components/aside-left/component.js
+++ b/app/components/aside-left/component.js
@@ -4,14 +4,15 @@ const {Component, computed, get, inject} = Ember;
 
 export default Component.extend({
 	uiStates: inject.service(),
+	player: inject.service(),
 	tagName: 'aside',
 	classNames: ['Aside', 'Aside--left'],
 
 	isActive: computed.alias('uiStates.isPanelLeftVisible'),
 
 	actions: {
-		addTrack() {
-			get(this, 'toggleModal')();
+		addTrack(trackModel) {
+			get(this, 'onClick')(trackModel);
 		}
 	}
 });

--- a/app/components/aside-left/template.hbs
+++ b/app/components/aside-left/template.hbs
@@ -10,7 +10,7 @@
 {{aside-left-toggle}}
 
 <div class="Aside-inner">
-	<div class="Tabs">
+	<div class="Tabs Tabs--vertical">
 		{{#link-to
 				 "channels"
 				 title="Find radio channels to enjoy [⌨ g h]"

--- a/app/components/aside-left/template.hbs
+++ b/app/components/aside-left/template.hbs
@@ -23,12 +23,22 @@
 					channel=userChannel
 					wide=true
 					title="Your radio [⌨ g i]"}}
-			<button
-				{{action "addTrack"}}
-				class="Btn Btn--important Btn--topNoRadius"
-				title="Add a new track to your radio [⌨ g a]">
-				Add track
-			</button>
+			{{#btn-group class="BtnGroup--full"}}
+				<button
+					{{action "addTrack"}}
+					class="Btn Btn--important Btn--topNoRadius"
+					title="Add a new track to your radio [⌨ g a]">
+					Add track
+				</button>
+				{{#if player.isPlaying}}
+				<button
+					{{action "addTrack" player.originTrack}}
+					class="Btn Btn--small Btn--topNoRadius"
+					title="Add a current track to your radio [⌨ a]">
+					+
+				</button>
+				{{/if}}
+			{{/btn-group}}
 		{{/if}}
 
 		{{#unless userChannel}}

--- a/app/components/aside-left/template.hbs
+++ b/app/components/aside-left/template.hbs
@@ -30,14 +30,6 @@
 					title="Add a new track to your radio [⌨ g a]">
 					Add track
 				</button>
-				{{#if player.isPlaying}}
-				<button
-					{{action "addTrack" player.originTrack}}
-					class="Btn Btn--small Btn--topNoRadius"
-					title="Add a current track to your radio [⌨ a]">
-					+
-				</button>
-				{{/if}}
 			{{/btn-group}}
 		{{/if}}
 

--- a/app/components/play-random-channel/component.js
+++ b/app/components/play-random-channel/component.js
@@ -1,36 +1,18 @@
 import Ember from 'ember';
-const {Component, inject, get, on, computed} = Ember;
-import {getRandomIndex} from 'radio4000/utils/random-helpers';
-import {EKMixin, keyUp} from 'ember-keyboard';
+const {
+	Component,
+	inject,
+	get
+} = Ember;
 
-export default Component.extend(EKMixin, {
-	store: inject.service(),
+export default Component.extend({
 	player: inject.service(),
 	tagNames: ['button'],
 	classNames: ['Btn'],
 	attributeBindings: ['title'],
 	title: 'Play a random Radio4000 channel [⌨ r]',
-	isVisible: computed.not('keyboardActivated'),
-
-	bindKeyboard: on(keyUp('KeyR'), function () {
-		this.playRandomChannel();
-	}),
 
 	click() {
-		this.playRandomChannel();
-	},
-
-	playRandomChannel() {
-		const store = this.get('store');
-		store.findAll('channel').then(data => {
-			const channel = data.objectAt(getRandomIndex(data.content));
-			channel.get('tracks').then(tracks => {
-				if (tracks.length < 2) {
-					this.playRandomChannel();
-				} else {
-					get(this, 'player').playTrack(tracks.get('lastObject'));
-				}
-			});
-		});
+		get(this, 'player.playRandomChannel').perform();
 	}
 });

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -45,8 +45,8 @@ export default TrackFormComponent.extend({
 		},
 		inviteToPremium() {
 			const message = `Hello!
-This feature can be used by upgraded channels only.
-Go to your settings to upgrade your Radio.`
+This feature is for upgraded channels only.
+Go to your settings to upgrade your radio.`
 			get(this, 'flashMessages').info(message, {
 				timeout: 5000
 			})

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -14,7 +14,6 @@ const {
 const trackObject = Ember.Object.extend(Validations);
 
 export default TrackFormComponent.extend({
-	session: inject.service(),
 	player: inject.service(),
 	flashMessages: inject.service(),
 	disableSubmit: computed.or('submitTask.isRunning', 'isSubmitting', 'track.validations.isInvalid'),

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -15,6 +15,7 @@ const trackObject = Ember.Object.extend(Validations);
 
 export default TrackFormComponent.extend({
 	player: inject.service(),
+	session: inject.service(),
 	flashMessages: inject.service(),
 	disableSubmit: computed.or('submitTask.isRunning', 'isSubmitting', 'track.validations.isInvalid'),
 

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -33,13 +33,14 @@ export default TrackFormComponent.extend({
 		this._super(...arguments);
 		this.resetForm();
 	},
+
 	actions: {
 		prefillCurrentTrack() {
 			const currentTrack = get(this, 'player.currentTrack');
 			get(this, 'track').setProperties({
 				url: currentTrack.get('url'),
 				title: currentTrack.get('title'),
-				body: `thx @${currentTrack.get('channel.slug')}`
+				body: `thanks @${currentTrack.get('channel.slug')}`
 			});
 		},
 		inviteToPremium() {

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -35,10 +35,12 @@ export default TrackFormComponent.extend({
 	actions: {
 		prefillCurrentTrack() {
 			const currentTrack = get(this, 'player.currentTrack');
-			console.log('currentTrack', currentTrack)
+			const currentChannel = get(this, 'player.currentChannel');
+			console.log('currentChannel', currentChannel);
 			get(this, 'track').setProperties({
 				url: currentTrack.get('url'),
-				body: `thx @${currentTrack.channel.slug}`
+				title: currentTrack.get('title'),
+				body: `thx @${currentChannel.get('slug')}`
 			});
 		}
 	}

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -2,13 +2,19 @@ import Ember from 'ember';
 import TrackFormComponent from 'radio4000/components/track-form/component';
 import {Validations} from 'radio4000/models/track';
 
-const {get, set, computed} = Ember;
+const {
+	inject,
+	get,
+	set,
+	computed
+} = Ember;
 
 // Use a normal object instead af a model.
 // This avoids it appearing in the UI before it is saved.
 const trackObject = Ember.Object.extend(Validations);
 
 export default TrackFormComponent.extend({
+	player: inject.service(),
 	disableSubmit: computed.or('submitTask.isRunning', 'isSubmitting', 'track.validations.isInvalid'),
 
 	// Called on init as well as after submitting a track.

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -48,7 +48,7 @@ export default TrackFormComponent.extend({
 This feature is for upgraded channels only.
 Go to your settings to upgrade your radio.`
 			get(this, 'flashMessages').info(message, {
-				timeout: 5000
+				timeout: 50000
 			})
 		}
 	}

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -31,5 +31,16 @@ export default TrackFormComponent.extend({
 	init() {
 		this._super(...arguments);
 		this.resetForm();
+	},
+	actions: {
+		prefillCurrentTrack() {
+			const currentTrack = get(this, 'player.currentTrack');
+			console.log('currentTrack', currentTrack)
+			get(this, 'track').setProperties({
+				url: currentTrack.get('url'),
+				body: `thx @${currentTrack.channel.slug}`
+			});
+		}
 	}
+
 });

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -47,9 +47,7 @@ export default TrackFormComponent.extend({
 			const message = `Hello!
 This feature is for upgraded channels only.
 Go to your settings to upgrade your radio.`
-			get(this, 'flashMessages').info(message, {
-				timeout: 50000
-			})
+			get(this, 'flashMessages').info(message)
 		}
 	}
 });

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -14,16 +14,18 @@ const {
 const trackObject = Ember.Object.extend(Validations);
 
 export default TrackFormComponent.extend({
+	session: inject.service(),
 	player: inject.service(),
+	flashMessages: inject.service(),
 	disableSubmit: computed.or('submitTask.isRunning', 'isSubmitting', 'track.validations.isInvalid'),
 
 	// Called on init as well as after submitting a track.
 	// Also see the same method on the `TrackForm` component, from which this extends.
 	resetForm() {
 		// The getOwner part is mentioned in the ember-cp-validation docs.
-		const track = trackObject.create(Ember.getOwner(this).ownerInjection(), {
-			url: get(this, 'initialUrl')
-		});
+			const track = trackObject.create(Ember.getOwner(this).ownerInjection(), {
+				url: get(this, 'initialUrl')
+			});
 		set(this, 'track', track);
 		this._super(...arguments);
 	},
@@ -42,6 +44,14 @@ export default TrackFormComponent.extend({
 				title: currentTrack.get('title'),
 				body: `thx @${currentChannel.get('slug')}`
 			});
+		},
+		inviteToPremium() {
+			const message = `Hello!
+This feature can be used by upgraded channels only.
+Go to your settings to upgrade your Radio.`
+			get(this, 'flashMessages').info(message, {
+				timeout: 5000
+			})
 		}
 	}
 

--- a/app/components/track-form-add/component.js
+++ b/app/components/track-form-add/component.js
@@ -3,10 +3,10 @@ import TrackFormComponent from 'radio4000/components/track-form/component';
 import {Validations} from 'radio4000/models/track';
 
 const {
-	inject,
 	get,
 	set,
-	computed
+	computed,
+	inject
 } = Ember;
 
 // Use a normal object instead af a model.
@@ -22,9 +22,9 @@ export default TrackFormComponent.extend({
 	// Also see the same method on the `TrackForm` component, from which this extends.
 	resetForm() {
 		// The getOwner part is mentioned in the ember-cp-validation docs.
-			const track = trackObject.create(Ember.getOwner(this).ownerInjection(), {
-				url: get(this, 'initialUrl')
-			});
+		const track = trackObject.create(Ember.getOwner(this).ownerInjection(), {
+			url: get(this, 'initialUrl')
+		});
 		set(this, 'track', track);
 		this._super(...arguments);
 	},
@@ -36,12 +36,10 @@ export default TrackFormComponent.extend({
 	actions: {
 		prefillCurrentTrack() {
 			const currentTrack = get(this, 'player.currentTrack');
-			const currentChannel = get(this, 'player.currentChannel');
-			console.log('currentChannel', currentChannel);
 			get(this, 'track').setProperties({
 				url: currentTrack.get('url'),
 				title: currentTrack.get('title'),
-				body: `thx @${currentChannel.get('slug')}`
+				body: `thx @${currentTrack.get('channel.slug')}`
 			});
 		},
 		inviteToPremium() {
@@ -53,5 +51,4 @@ Go to your settings to upgrade your Radio.`
 			})
 		}
 	}
-
 });

--- a/app/components/track-form-add/template.hbs
+++ b/app/components/track-form-add/template.hbs
@@ -38,6 +38,7 @@
 				<button
 					{{action "prefillCurrentTrack"}}
 					class="Btn"
+					type="button"
 					title="Add the current 'on air' track into your radio [⌨ a]">
 					Copy current track
 				</button>
@@ -48,6 +49,7 @@
 			<button
 				{{action "inviteToPremium"}}
 				class="Btn"
+				type="button"
 				title="(Upgrade) Add the current 'on air' track into your radio [⌨ a]">
 				Copy current track
 			</button>

--- a/app/components/track-form-add/template.hbs
+++ b/app/components/track-form-add/template.hbs
@@ -1,9 +1,8 @@
 {{#if player.isPlaying}}
-
-	{{#btn-group}}
+	{{#btn-group class="BtnGroup--right"}}
 		<!-- <span class="BtnGroup-label">Which track?</span> -->
 		<button
-			{{action "addTrack" player.originTrack}}
+			{{action "prefillCurrentTrack"}}
 			class="Btn"
 			title="Add the current 'on air' track into your radio [⌨ a]">
 			Add current track

--- a/app/components/track-form-add/template.hbs
+++ b/app/components/track-form-add/template.hbs
@@ -1,3 +1,28 @@
+{{#if player.isPlaying}}
+	<div class="u-dn">
+		{{#btn-group class="BtnGroup--right"}}
+			{{#if session.currentUser.channels.firstObject.isPremium}}
+				<button
+					{{action "prefillCurrentTrack"}}
+					class="Btn"
+					type="button"
+					title="Add the current 'on air' track into your radio [⌨ a]">
+					Copy current track
+				</button>
+			{{else}}
+				<button
+					{{action "inviteToPremium"}}
+					class="Btn Muted"
+					type="button"
+					title="(Upgrade) Add the current 'on air' track into your radio [⌨ a]">
+					Copy current track
+				</button>
+			{{/if}}
+		{{/btn-group}}
+	</div>
+{{/if}}
+
+
 {{#form-group
 	model=track
 	valuePath="url"
@@ -31,31 +56,6 @@
 {{/form-group}}
 
 <div class="Form-group">
-	{{#if session.currentUser.channels.firstObject.isPremium}}
-		{{#if player.isPlaying}}
-			{{#btn-group}}
-				<!-- <span class="BtnGroup-label">Which track?</span> -->
-				<button
-					{{action "prefillCurrentTrack"}}
-					class="Btn"
-					type="button"
-					title="Add the current 'on air' track into your radio [⌨ a]">
-					Copy current track
-				</button>
-			{{/btn-group}}
-		{{/if}}
-	{{else}}
-		{{#btn-group}}
-			<button
-				{{action "inviteToPremium"}}
-				class="Btn"
-				type="button"
-				title="(Upgrade) Add the current 'on air' track into your radio [⌨ a]">
-				Copy current track
-			</button>
-		{{/btn-group}}
-	{{/if}}
-
 	{{#btn-group class="BtnGroupWrapper BtnGroupWrapper--full"}}
 		<button {{action "submit"}} type="submit" class="Btn Btn--important" title="Add track to your radio" disabled={{disableSubmit}}>
 			{{if submitTask.isIdle "Add track" "Adding…"}}

--- a/app/components/track-form-add/template.hbs
+++ b/app/components/track-form-add/template.hbs
@@ -39,7 +39,7 @@
 					{{action "prefillCurrentTrack"}}
 					class="Btn"
 					title="Add the current 'on air' track into your radio [⌨ a]">
-					Repost current track
+					Copy current track
 				</button>
 			{{/btn-group}}
 		{{/if}}
@@ -49,7 +49,7 @@
 				{{action "inviteToPremium"}}
 				class="Btn"
 				title="(Upgrade) Add the current 'on air' track into your radio [⌨ a]">
-				Repost current track
+				Copy current track
 			</button>
 		{{/btn-group}}
 	{{/if}}

--- a/app/components/track-form-add/template.hbs
+++ b/app/components/track-form-add/template.hbs
@@ -1,15 +1,3 @@
-{{#if player.isPlaying}}
-	{{#btn-group class="BtnGroup--right"}}
-		<!-- <span class="BtnGroup-label">Which track?</span> -->
-		<button
-			{{action "prefillCurrentTrack"}}
-			class="Btn"
-			title="Add the current 'on air' track into your radio [⌨ a]">
-			Add current track
-		</button>
-	{{/btn-group}}
-{{/if}}
-
 {{#form-group
 	model=track
 	valuePath="url"
@@ -35,18 +23,41 @@
 {{/form-group}}
 
 {{#form-group
-	model=track
-	valuePath="body"
-	label="Description"
-	hint="Give your track an optional description" as |value|}}
+		 model=track
+		 valuePath="body"
+		 label="Description"
+		 hint="Give your track an optional description" as |value|}}
 	{{textarea value=value placeholder="Fantastic track! #fantastic (optional)"}}<br>
 {{/form-group}}
 
 <div class="Form-group">
+	{{#if session.currentUser.channels.firstObject.isPremium}}
+		{{#if player.isPlaying}}
+			{{#btn-group}}
+				<!-- <span class="BtnGroup-label">Which track?</span> -->
+				<button
+					{{action "prefillCurrentTrack"}}
+					class="Btn"
+					title="Add the current 'on air' track into your radio [⌨ a]">
+					Repost current track
+				</button>
+			{{/btn-group}}
+		{{/if}}
+	{{else}}
+		{{#btn-group}}
+			<button
+				{{action "inviteToPremium"}}
+				class="Btn"
+				title="(Upgrade) Add the current 'on air' track into your radio [⌨ a]">
+				Repost current track
+			</button>
+		{{/btn-group}}
+	{{/if}}
+
 	{{#btn-group class="BtnGroupWrapper BtnGroupWrapper--full"}}
 		<button {{action "submit"}} type="submit" class="Btn Btn--important" title="Add track to your radio" disabled={{disableSubmit}}>
 			{{if submitTask.isIdle "Add track" "Adding…"}}
 		</button>
-		<button {{action "cancel"}} type="button" class="Btn Btn--text" title="Go back, do not add the track">Cancel</button>
+		<button {{action "cancel"}} type="button" class="Btn" title="Go back, do not add the track">Cancel</button>
 	{{/btn-group}}
 </div>

--- a/app/components/track-form-add/template.hbs
+++ b/app/components/track-form-add/template.hbs
@@ -1,3 +1,16 @@
+{{#if player.isPlaying}}
+
+	{{#btn-group}}
+		<!-- <span class="BtnGroup-label">Which track?</span> -->
+		<button
+			{{action "addTrack" player.originTrack}}
+			class="Btn"
+			title="Add the current 'on air' track into your radio [⌨ a]">
+			Add current track
+		</button>
+	{{/btn-group}}
+{{/if}}
+
 {{#form-group
 	model=track
 	valuePath="url"

--- a/app/mixins/keyboard-shortcuts-global.js
+++ b/app/mixins/keyboard-shortcuts-global.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+import $ from 'jquery'
 import Mixin from '@ember/object/mixin'
 import {EKMixin, keyUp} from 'ember-keyboard'
 
@@ -9,10 +10,6 @@ const {
 	run,
 	inject
 } = Ember
-
-/*CHAT BUFFER
-
-*/
 
 export default Mixin.create(EKMixin, {
 	player: inject.service(),
@@ -36,6 +33,25 @@ export default Mixin.create(EKMixin, {
 			this.transitionTo.apply(this, arguments)
 		}
 	},
+
+	triggerClickOnPlayer(selector) {
+		const el = document.querySelector(`${selector}`)
+		if (!el) return
+		$(el).trigger('click')
+	},
+
+	playPause: on(keyUp('KeyP'), function() {
+		this.triggerClickOnPlayer('radio4000-player .PlayPause-state')
+	}),
+	playNext: on(keyUp('KeyN'), function() {
+		this.triggerClickOnPlayer('radio4000-player .Btn--next')
+	}),
+	toggleShuffle: on(keyUp('KeyS'), function() {
+		this.triggerClickOnPlayer('radio4000-player .Btn--shuffle')
+	}),
+	toggleMute: on(keyUp('KeyM'), function() {
+		this.triggerClickOnPlayer('radio4000-player .Btn--mute')
+	}),
 
 	onKeyR: on(keyUp('KeyR'), function () {
 		if (get(this, 'isGoingTo')) {

--- a/app/mixins/keyboard-shortcuts-global.js
+++ b/app/mixins/keyboard-shortcuts-global.js
@@ -36,8 +36,9 @@ export default Mixin.create(EKMixin, {
 
 	triggerClickOnPlayer(selector) {
 		const el = document.querySelector(`${selector}`)
-		if (!el) return
-		$(el).trigger('click')
+		if (el) {
+			$(el).trigger('click')
+		}
 	},
 
 	playPause: on(keyUp('KeyP'), function() {

--- a/app/mixins/keyboard-shortcuts-global.js
+++ b/app/mixins/keyboard-shortcuts-global.js
@@ -6,7 +6,8 @@ const {
 	set,
 	get,
 	on,
-	run
+	run,
+	inject
 } = Ember
 
 /*CHAT BUFFER
@@ -14,6 +15,8 @@ const {
 */
 
 export default Mixin.create(EKMixin, {
+	player: inject.service(),
+
 	// https://github.com/patience-tema-baron/ember-keyboard/issues/54
 	isGoingTo: false,
 
@@ -29,27 +32,18 @@ export default Mixin.create(EKMixin, {
 	}),
 
 	goingTo() {
-		if (get(this, 'isGoingTo')) {			
+		if (get(this, 'isGoingTo')) {
 			this.transitionTo.apply(this, arguments)
 		}
 	},
 
 	onKeyR: on(keyUp('KeyR'), function () {
 		if (get(this, 'isGoingTo')) {
-			this.transitionTo('channels.all')
+			this.transitionTo('channels.all');
 		} else {
-			alert('play random')
+			get(this, 'player.playRandomChannel').perform();
 		}
 	}),
-	// goingTo not defined
-	// it says
-	// can't see what it is. had it working locally here some days ago
-	// TypeError: undefined has no properties , line 44
-	// wait wait
-	// gotoHome: on(keyUp('KeyH'), function () {
-		// this.goingTo('application')
-	// }),
-	// I think the arrow functions are messing it up
 	gotoHome: on(keyUp('KeyH'), function() {
 		this.goingTo('application')
 	}),
@@ -65,11 +59,6 @@ export default Mixin.create(EKMixin, {
 	gotoFeedback: on(keyUp('KeyF'), function() {
 		this.goingTo('feedback')
 	}),
-	// gotoHome: on(keyUp('KeyH'), () => this.goingTo('application')),
-	// gotoMap: on(keyUp('KeyM'), () => this.goingTo('channels.map')),
-	// gotoHistory: on(keyUp('KeyY'), () => this.goingTo('channels.history')),
-	// gotoAddTrack: on(keyUp('KeyA'), () => this.goingTo('add')),
-	// gotoFeedback: on(keyUp('KeyF'), () => this.goingTo('feedback')),
 
 	// go `I`
 	gotoMyRadio: on(keyUp('KeyI'), function() {

--- a/app/mixins/keyboard-shortcuts-global.js
+++ b/app/mixins/keyboard-shortcuts-global.js
@@ -1,101 +1,111 @@
-import Ember from 'ember';
-import Mixin from '@ember/object/mixin';
-import {EKMixin, keyUp} from 'ember-keyboard';
+import Ember from 'ember'
+import Mixin from '@ember/object/mixin'
+import {EKMixin, keyUp} from 'ember-keyboard'
 
 const {
 	set,
 	get,
 	on,
 	run
-} = Ember;
+} = Ember
+
+/*CHAT BUFFER
+
+*/
 
 export default Mixin.create(EKMixin, {
 	// https://github.com/patience-tema-baron/ember-keyboard/issues/54
 	isGoingTo: false,
 
 	activateKeyboard: Ember.on('init', function() {
-		set(this, 'keyboardActivated', true);
+		set(this, 'keyboardActivated', true)
 	}),
 
 	goto: on(keyUp('KeyG'), function() {
-		set(this, 'isGoingTo', true);
+		set(this, 'isGoingTo', true)
 		run.later(() => {
-			set(this, 'isGoingTo', false);
-		}, 500);
+			set(this, 'isGoingTo', false)
+		}, 500)
 	}),
 
+	goingTo() {
+		if (get(this, 'isGoingTo')) {			
+			this.transitionTo.apply(this, arguments)
+		}
+	},
+
+	onKeyR: on(keyUp('KeyR'), function () {
+		if (get(this, 'isGoingTo')) {
+			this.transitionTo('channels.all')
+		} else {
+			alert('play random')
+		}
+	}),
+	// goingTo not defined
+	// it says
+	// can't see what it is. had it working locally here some days ago
+	// TypeError: undefined has no properties , line 44
+	// wait wait
+	// gotoHome: on(keyUp('KeyH'), function () {
+		// this.goingTo('application')
+	// }),
+	// I think the arrow functions are messing it up
 	gotoHome: on(keyUp('KeyH'), function() {
-		if (get(this, 'isGoingTo')) {
-			this.transitionTo('application');
-		}
+		this.goingTo('application')
 	}),
-
-	gotoRadios: on(keyUp('KeyR'), function() {
-		if (get(this, 'isGoingTo')) {
-			this.transitionTo('channels.all');
-		}
-	}),
-
 	gotoMap: on(keyUp('KeyM'), function() {
-		if (get(this, 'isGoingTo')) {
-			this.transitionTo('channels.map');
-		}
+		this.goingTo('channels.map')
 	}),
-
 	gotoHistory: on(keyUp('KeyY'), function() {
-		if (get(this, 'isGoingTo')) {
-			this.transitionTo('channels.history');
-		}
+		this.goingTo('channels.history')
 	}),
+	gotoAddTrack: on(keyUp('KeyA'), function() {
+		this.goingTo('add')
+	}),
+	gotoFeedback: on(keyUp('KeyF'), function() {
+		this.goingTo('feedback')
+	}),
+	// gotoHome: on(keyUp('KeyH'), () => this.goingTo('application')),
+	// gotoMap: on(keyUp('KeyM'), () => this.goingTo('channels.map')),
+	// gotoHistory: on(keyUp('KeyY'), () => this.goingTo('channels.history')),
+	// gotoAddTrack: on(keyUp('KeyA'), () => this.goingTo('add')),
+	// gotoFeedback: on(keyUp('KeyF'), () => this.goingTo('feedback')),
 
 	// go `I`
 	gotoMyRadio: on(keyUp('KeyI'), function() {
 		const userChannel = get(this, 'session.currentUser.channels.firstObject')
-		if (get(this, 'isGoingTo') && userChannel) {
-			this.transitionTo('channel.index', userChannel);
+		if (userChannel) {
+			this.goingTo('channel.index', userChannel)
 		}
 	}),
 
 	// go `Starred`
 	gotoMyRadioFavorites: on(keyUp('KeyS'), function() {
 		const userChannel = get(this, 'session.currentUser.channels.firstObject')
-		if (get(this, 'isGoingTo') && userChannel) {
-			this.transitionTo('channel.favorites', userChannel);
+		if (userChannel) {
+			this.goingTo('channel.favorites', userChannel)
 		}
 	}),
 
-	// go `Starred`
 	gotoMyRadioTracks: on(keyUp('KeyT'), function() {
-		const userChannel = get(this, 'session.currentUser.channels.firstObject')
-		if (get(this, 'isGoingTo') && userChannel) {
-			this.transitionTo('channel.tracks', userChannel);
-		}
-	}),
-
-	gotoAddTrack: on(keyUp('KeyA'), function() {
-		if (get(this, 'isGoingTo')) {
-			this.transitionTo('add');
-		}
-	}),
-
-	gotoFeedback: on(keyUp('KeyF'), function() {
-		if (get(this, 'isGoingTo')) {
-			this.transitionTo('feedback');
+		const userChannel = get(this, 'session1.currentUser.channels.firstObject')
+		if (userChannel) {
+			this.goingTo('channel.tracks', userChannel)
 		}
 	}),
 
 	gotoCurrentChannel: on(keyUp('KeyC'), function() {
-		const currentChannel = get(this, 'player.currentChannel');
-		if (get(this, 'isGoingTo') && currentChannel) {
-			this.transitionTo('channel', currentChannel);
+		const currentChannel = get(this, 'player.currentChannel')
+		if (currentChannel) {
+			this.goingTo('channel', currentChannel)
 		}
 	}),
 
 	gotoCurrentTrack: on(keyUp('KeyX'), function() {
-		const currentTrack = get(this, 'player.currentTrack');
-		const currentChannel = get(this, 'player.currentChannel');
-		if (get(this, 'isGoingTo') && currentTrack) {
-			this.transitionTo('channel.tracks.track', currentChannel, currentTrack);
+		const currentChannel = get(this, 'player.currentChannel')
+		const currentTrack = get(this, 'player.currentTrack')
+		if (currentChannel && currentTrack) {
+			this.goingTo('channel.tracks.track', currentChannel, currentTrack)
 		}
 	})
-});
+})

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,7 +1,7 @@
 /* !
-	RADIO4000
-	by Hugo Vieilledent and Oskar Rough Mosumgaard
-*/
+	 RADIO4000
+	 by Hugo Vieilledent and Oskar Rough Mosumgaard
+ */
 
 // Third party (imported from `./node_modules` because we use postcss-import)
 @import "node_modules/normalize.css/normalize";
@@ -17,6 +17,7 @@
 @import "utilities/text";
 @import "utilities/mediablock";
 @import "utilities/flex";
+@import "utilities/displays";
 
 // Base (config and everything else without classes)
 @import "base/colors";

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -61,6 +61,9 @@ em {
 		position: relative;
 		top: -0.12em;
 	}
+	a {
+		color: inherit;
+	}
 }
 
 .Muted--strong {
@@ -141,4 +144,3 @@ pre,
 	color: $text-color;
 	padding: 3px 4px 0;
 }
-

--- a/app/styles/components/_button-group.scss
+++ b/app/styles/components/_button-group.scss
@@ -43,6 +43,8 @@
 
 .BtnGroup--right {
 	justify-content: flex-end;
+	padding-right: 0;
+	padding-left: 1rem;
 }
 
 .BtnGroup-label {
@@ -78,4 +80,5 @@
 
 .BtnGroupWrapper--full {
 	justify-content: space-between;
+	padding-right: 0;
 }

--- a/app/styles/components/_flash-messages.scss
+++ b/app/styles/components/_flash-messages.scss
@@ -1,6 +1,7 @@
 .FlashMessages {
 	@include size-1;
 	position: fixed;
+	z-index: 52; // over player
 	top: 1.4rem;
 	right: 0.7rem;
 	max-width: 20rem;
@@ -8,7 +9,6 @@
 
 .alert {
 	position: relative;
-	z-index: 51;
 	display: table;
 	float: right;
 	clear: both;

--- a/app/styles/components/_flash-messages.scss
+++ b/app/styles/components/_flash-messages.scss
@@ -1,6 +1,5 @@
 .FlashMessages {
 	@include size-1;
-	z-index: 51;
 	position: fixed;
 	top: 1.4rem;
 	right: 0.7rem;
@@ -8,6 +7,8 @@
 }
 
 .alert {
+	position: relative;
+	z-index: 51;
 	display: table;
 	float: right;
 	clear: both;

--- a/app/styles/components/_flash-messages.scss
+++ b/app/styles/components/_flash-messages.scss
@@ -1,6 +1,6 @@
 .FlashMessages {
 	@include size-1;
-	z-index: 3;
+	z-index: 51;
 	position: fixed;
 	top: 1.4rem;
 	right: 0.7rem;

--- a/app/styles/components/_list.scss
+++ b/app/styles/components/_list.scss
@@ -53,7 +53,7 @@
 		text-decoration: none;
 	}
 
-	@media (min-width: $layout-s) {
+	@media (min-width: $layout-m) {
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}

--- a/app/styles/components/_manchet.scss
+++ b/app/styles/components/_manchet.scss
@@ -17,7 +17,7 @@
 		padding-left: 1.5rem;
 		margin-bottom: 0;
 		.ember-modal-overlay & {
-			padding-left: 0;xz
+			padding-left: 0;
 		}
 	}
 

--- a/app/styles/components/_manchet.scss
+++ b/app/styles/components/_manchet.scss
@@ -14,9 +14,10 @@
 	z-index: 1;
 
 	h1, h2, h3 {
-		padding-left: 1rem;
+		padding-left: 1.5rem;
 		margin-bottom: 0;
 	}
+
 
 	p {
 		flex-basis: 100%;

--- a/app/styles/components/_manchet.scss
+++ b/app/styles/components/_manchet.scss
@@ -16,6 +16,9 @@
 	h1, h2, h3 {
 		padding-left: 1.5rem;
 		margin-bottom: 0;
+		.ember-modal-overlay & {
+			padding-left: 0;xz
+		}
 	}
 
 

--- a/app/styles/components/_tabs.scss
+++ b/app/styles/components/_tabs.scss
@@ -57,8 +57,10 @@
 }
 
 .Tabs .BtnGroup {
-	padding-top: 0.2em;
+	padding-top: 0em;
 	padding-bottom: 0.2em;
+	padding-right: 0;
+	margin-bottom: 0;
 }
 
 .Tabs-divider {
@@ -70,6 +72,11 @@
 /**
  * Modifiers
  */
+.Tabs--vertical {
+	.Tabs-item.BtnGroup {
+		padding-left: 0;
+	}
+}
 
 .Tabs--horizontal {
 	flex-flow: row nowrap;

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -33,6 +33,11 @@
 			opacity: 1;
 		}
 	}
+	.Manchet {
+		h1, h2, h3 {
+			padding-left: 0;
+		}
+	}
 }
 
 

--- a/app/styles/utilities/_displays.scss
+++ b/app/styles/utilities/_displays.scss
@@ -1,0 +1,3 @@
+.u-dn {
+	display: none;
+}

--- a/tests/integration/components/track-form-add/component-test.js
+++ b/tests/integration/components/track-form-add/component-test.js
@@ -1,8 +1,17 @@
 import {moduleForComponent, test} from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service'
+
+const sessionStub = Service.extend({})
 
 moduleForComponent('track-form-add', 'Integration | Component | track form add', {
-	integration: true
+	integration: true,
+	beforeEach: function () {
+		this.register('service:session', sessionStub);
+		// Calling inject puts the service instance in the context of the test,
+		// making it accessible as "locationService" within each test
+		this.inject.service('session', { as: 'sessionService' });
+	}
 });
 
 test('it renders', function (assert) {


### PR DESCRIPTION
- [x] make a button that posts the curent track

That opens the add `track overlay` or `/add` rout, prefilled with
- [x] prefil `add-form` with `current track`
- [x] with the `track.title`: track.title origin of repost
- [x] with the `track.body`: `txh @$channelSlug` channel origin of repost

For the future

- [ ] make a contextual button on each `track` and have `option:repost-track`
- [ ] prefil `add-form` with `selected-track`