### PR TITLE
Improve play buttons

### DIFF
--- a/app/channels/index/template.hbs
+++ b/app/channels/index/template.hbs
@@ -15,8 +15,7 @@
 						<p>Otherwise, let's explore!</p>
 						<p>
 						{{#btn-group class="BtnGroup--full BtnGroup--vertical"}}
-							{{play-random-channel
-									class="Btn--large"}}
+							{{play-random-channel class="Btn--large"}}
 							<a
 								class="Btn Btn--text"
 								href="{{href-to 'about.intro'}}"

--- a/app/channels/search/controller.js
+++ b/app/channels/search/controller.js
@@ -23,9 +23,6 @@ export default Controller.extend({
 	noSearch: computed.not('search'),
 
 	actions: {
-		changeLayout() {
-			this.toggleProperty('isList')
-		},
 		clearSearch() {
 			set(this, 'search', '')
 		}

--- a/app/channels/search/template.hbs
+++ b/app/channels/search/template.hbs
@@ -42,19 +42,19 @@
 								"Activity"
 								"channels.search"
 								(query-params sort="updated")
-								class='Btn'
+								class="Btn"
 								title="Sort by activity, last updated date"}}
 						{{link-to
 								"Age"
 								"channels.search"
 								(query-params sort="created")
-								class='Btn'
+								class="Btn"
 								title="Sort by age, created date"}}
 						{{link-to
 								"A-Z"
 								"channels.search"
 								(query-params sort="title")
-								class='Btn'
+								class="Btn"
 								title="Sort by alphabetic order of titles"}}
 					</label>
 				{{/btn-group}}
@@ -63,13 +63,13 @@
 						"↑"
 						"channels.search"
 						(query-params sortDirection="asc")
-						class='Btn'
+						class="Btn"
 						title="Sort direction: ascending"}}
 					{{link-to
 						"↓"
 						"channels.search"
 						(query-params sortDirection="desc")
-						class='Btn'
+						class="Btn"
 						title="Sort direction: descending"}}
 				{{/btn-group}}
 			</div>
@@ -89,7 +89,7 @@
 				{{#if filteredChannels}}
 					{{#each manipulatedList as |item|}}
 						<div class="Grid-cell">
-							{{channel-card channel=item wide=isList}}
+							{{channel-card channel=item}}
 						</div>
 					{{/each}}
 				{{else}}

--- a/app/channels/search/template.hbs
+++ b/app/channels/search/template.hbs
@@ -30,10 +30,6 @@
 				{{/btn-group}}
 
 				{{#btn-group}}
-					{{play-random-channel class="Btn--large"}}
-				{{/btn-group}}
-
-				{{#btn-group}}
 					<label class="Label Label--horizontal">
 						<span class="Label-title">
 							Sort by
@@ -82,9 +78,12 @@
 					</p>
 					{{#unless session.currentUser.channels.firstObject}}
 						<p>
-							If you feel like sharing yours, we welcome you to <a href="{{href-to "auth.login"}}" title="">create your own radio</a>.
+							Feel like sharing yours? We welcome you to <a href="{{href-to "auth.login"}}">create your own radio</a>.
 						</p>
 					{{/unless}}
+					<p>
+						{{play-random-channel class="Btn--large"}}
+					</p>
 				</div>
 				{{#if filteredChannels}}
 					{{#each manipulatedList as |item|}}

--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -1,13 +1,14 @@
 /* global document */
 import Ember from 'ember';
+import { inject as service } from '@ember/service'
 
-const {Component, inject, run, get, set} = Ember;
+const {Component, run, get, set} = Ember;
 
 export default Component.extend({
-	uiStates: inject.service(),
-	player: inject.service(),
-	store: inject.service(),
-	session: inject.service(),
+	uiStates: service(),
+	player: service(),
+	store: service(),
+	session: service(),
 
 	classNames: ['Root'],
 	classNameBindings: [

--- a/app/components/btn-favorite/component.js
+++ b/app/components/btn-favorite/component.js
@@ -1,39 +1,37 @@
-import Ember from 'ember';
+import Ember from 'ember'
+import Component from '@ember/component'
+import { inject as service } from '@ember/service'
+import {or, not} from 'ember-awesome-macros'
 
-const {Component,
-	inject,
-	computed,
-	get} = Ember;
+const { computed, get } = Ember
 
 export default Component.extend({
-	tagName: 'button',
-	session: inject.service(),
-	attributeBindings: ['title', 'disabled'],
-	classNames: ['Btn'],
-	disabled: computed('channel.toggleFavorite.isRunning', 'hasChannel', function() {
-		return !get(this, 'hasChannel') || get(this, 'channel.toggleFavorite.isRunning')
-	}),
-	hasChannel: computed.reads('session.content.currentUser.channels.firstObject'),
+	session: service(),
 
-	/* params */
-	// channel to be added as favorite to user.session
+	tagName: 'button',
+	classNames: ['Btn'],
+	attributeBindings: ['title', 'disabled'],
+
+	// Channel to be added as favorite to user.session
 	channel: null,
-	// display text in template or only icon
+	// Display text in template or only icon
 	showText: true,
 
+	hasChannel: computed.reads('session.content.currentUser.channels.firstObject'),
+	disabled: or(not('hasChannel'), 'channel.toggleFavorite.isRunning'),
 	title: computed('channel.isFavorite', {
 		get() {
 			if (!get(this, 'hasChannel')) {
 				return 'You need to login and have a channel to add this one as favorite'
 			}
 			if (!get(this, 'channel.isFavorite')) {
-				return 'Save this radio to your favorites';
+				return 'Save this radio to your favorites'
 			}
-			return 'Remove this radio from your favorites';
+			return 'Remove this radio from your favorites'
 		}
 	}),
 
 	click() {
-		return get(this, 'channel.toggleFavorite').perform();
+		get(this, 'channel.toggleFavorite').perform()
 	}
-});
+})

--- a/app/components/channel-card/template.hbs
+++ b/app/components/channel-card/template.hbs
@@ -7,7 +7,7 @@
 
 <div class="ChannelCard-controls">
 	{{play-shuffle-btn
-		class="Btn--small Btn--shake"
+		class="Btn--small"
 		channel=channel
 		showText=false
 	}}

--- a/app/components/channel-card/template.hbs
+++ b/app/components/channel-card/template.hbs
@@ -4,11 +4,13 @@
 		{{channel.title}}
 	</h3>
 {{/link-to}}
+
 <div class="ChannelCard-controls">
 	{{play-shuffle-btn
 		class="Btn--small Btn--shake"
 		channel=channel
-		showText=showText}}
+		showText=false
+	}}
 </div>
 <p class="ChannelCard-body">
 	{{do-truncate channel.body 200}}
@@ -18,7 +20,8 @@
 	{{btn-favorite
 		class="ChannelCard-favorite Btn Btn--text Muted"
 		channel=channel
-		showText=showText}}
+		showText=false
+	}}
 {{/unless}}
 
 {{yield}}

--- a/app/components/channel-card/template.hbs
+++ b/app/components/channel-card/template.hbs
@@ -6,7 +6,7 @@
 {{/link-to}}
 <div class="ChannelCard-controls">
 	{{play-shuffle-btn
-		class="Btn--small"
+		class="Btn--small Btn--shake"
 		channel=channel
 		showText=showText}}
 </div>

--- a/app/components/feedback-form-google-spreadsheet/component.js
+++ b/app/components/feedback-form-google-spreadsheet/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {task} from 'ember-concurrency'
 
 const {
 	Component,
@@ -47,30 +48,36 @@ export default Component.extend({
 		});
 	},
 
+	sendFeedback: task(function * () {
+		const notification = get(this, 'flashMessages');
+		const url = get(this, 'buildUrl');
+		const data = {
+			message: get(this, 'message'),
+			email: get(this, 'email'),
+			userChannelId: get(this, 'userChannelId'),
+			playerChannelId: get(this, 'playerChannelId'),
+			playerTrackId: get(this, 'playerTrackId')
+		};
+		// Tried to use `fetch` instead of `$.ajax` but could not get
+		// the Google Docs script to parse the incoming body.
+		try {
+			yield $.ajax({
+				type: 'post',
+				url,
+				data
+			})
+			this.clearData();
+			notification.success('Thank you for the feedback!');
+		} catch (err) {
+		}
+	}),
+
 	actions: {
 		send() {
 			if (get(this, 'botField')) {
-				return;
+				return
 			}
-			const notification = get(this, 'flashMessages');
-			const url = get(this, 'buildUrl');
-			const data = {
-				message: get(this, 'message'),
-				email: get(this, 'email'),
-				userChannelId: get(this, 'userChannelId'),
-				playerChannelId: get(this, 'playerChannelId'),
-				playerTrackId: get(this, 'playerTrackId')
-			};
-			// Tried to use `fetch` instead of `$.ajax` but could not get
-			// the Google Docs script to parse the incoming body.
-			return $.ajax({
-				url,
-				type: 'post',
-				data
-			}).then(() => {
-				this.clearData();
-				notification.success('Thank you for the feedback!');
-			});
+			get(this, 'sendFeedback').perform()
 		}
 	}
 });

--- a/app/components/feedback-form-google-spreadsheet/template.hbs
+++ b/app/components/feedback-form-google-spreadsheet/template.hbs
@@ -1,4 +1,4 @@
-<form class="Form" {{action "send" message email on="submit"}}>
+<form class="Form" {{action "send" on="submit"}}>
 	<div class="Form-group">
 		{{textarea
 			value=message
@@ -13,22 +13,24 @@
 	</div>
 
 	<div style="display:none;" class="Form-group">
-    <label>Don’t fill this out:
+		<label>Don’t fill this out:
 			{{input
 				value=botField
 				placeholder="This input is for botzzz, if filled, do not sent -_-"}}
 		</label>
-  </div>
+	</div>
 
 	<div class="BtnGroupWrapper BtnGroupWrapper--full">
-		{{async-button
-			class="Btn Btn--large"
-			action=(action "send" message email)
-			default="Send feedback"
-			pending="Sending..."
-			fulfilled="Sent!"
-			rejected="Error, try to refresh the page"
-			disableWhen=notValid
-			reset=message}}
+		<button type="submit" class="Btn Btn--large" disabled={{notValid}}>
+			{{#if sendFeedback.isRunning}}
+					Sending…
+				{{!-- {{else if sendFeedback.last.isSuccessful}}
+					Sent! --}}
+				{{else if sendFeedback.isError}}
+					Error, try to refresh the page
+				{{else}}
+					Send feedback
+				{{/if}}
+		</button>
 	</div>
 </form>

--- a/app/components/play-btn/component.js
+++ b/app/components/play-btn/component.js
@@ -10,7 +10,11 @@ export default Component.extend({
 	classNameBindings: ['clickTask.isRunning'],
 	attributeBindings: ['title'],
 	title: 'Play this radio',
+
+	// Display text in template or only icon
 	showText: true,
+
+	// Pass it a full `channel` model
 	// channel: {}
 
 	click() {

--- a/app/components/play-btn/component.js
+++ b/app/components/play-btn/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component'
 import { inject as service } from '@ember/service'
+import {computed} from '@ember/object'
 import {task} from 'ember-concurrency'
 
 export default Component.extend({
@@ -8,8 +9,9 @@ export default Component.extend({
 	tagName: 'button',
 	classNames: ['Btn'],
 	classNameBindings: ['clickTask.isRunning'],
-	attributeBindings: ['title'],
+	attributeBindings: ['disabled', 'title'],
 	title: 'Play this radio',
+	disabled: computed.reads('clickTask.isRunning'),
 
 	// Display text in template or only icon
 	showText: true,

--- a/app/components/play-btn/component.js
+++ b/app/components/play-btn/component.js
@@ -4,7 +4,7 @@ import {computed} from '@ember/object'
 import {task} from 'ember-concurrency'
 
 export default Component.extend({
-	player: service('player'),
+	player: service(),
 
 	tagName: 'button',
 	classNames: ['Btn'],

--- a/app/components/play-btn/component.js
+++ b/app/components/play-btn/component.js
@@ -1,22 +1,23 @@
-import Ember from 'ember';
-
-const {Component, inject, get} = Ember;
+import Component from '@ember/component'
+import { inject as service } from '@ember/service'
+import {task} from 'ember-concurrency'
 
 export default Component.extend({
-	player: inject.service('player'),
+	player: service('player'),
 
 	tagName: 'button',
 	classNames: ['Btn'],
+	classNameBindings: ['clickTask.isRunning'],
+	attributeBindings: ['title'],
+	title: 'Play this radio',
 	showText: true,
+	// channel: {}
 
 	click() {
-		this.playFirstTrack();
+		this.get('clickTask').perform()
 	},
 
-	playFirstTrack() {
-		get(this, 'channel.tracks').then(tracks => {
-			const firstTrack = tracks.get('lastObject');
-			get(this, 'player').playTrack(firstTrack);
-		});
-	}
-});
+	clickTask: task(function * () {
+		yield this.get('player.playFirstTrack').perform(this.get('channel'))
+	})
+})

--- a/app/components/play-random-channel/component.js
+++ b/app/components/play-random-channel/component.js
@@ -1,10 +1,13 @@
 import PlayButtonComponent from 'radio4000/components/play-btn/component'
-import {task} from 'ember-concurrency'
+import {task, timeout} from 'ember-concurrency'
 
 export default PlayButtonComponent.extend({
 	title: 'Play a random Radio4000 channel [⌨ r]',
 
 	clickTask: task(function * () {
 		yield this.get('player.playRandomChannel').perform()
+		// After the above task finishes, <radio4000-player> still
+		// needs to do stuff. We wait because it feels nicer #ux
+		yield timeout(250)
 	})
 })

--- a/app/components/play-random-channel/component.js
+++ b/app/components/play-random-channel/component.js
@@ -1,19 +1,10 @@
-import Ember from 'ember';
-const {
-	Component,
-	inject,
-	get
-} = Ember;
+import PlayButtonComponent from 'radio4000/components/play-btn/component'
+import {task} from 'ember-concurrency'
 
-export default Component.extend({
-	player: inject.service(),
-
-	tagName: 'button',
-	classNames: ['Btn'],
-	attributeBindings: ['title'],
+export default PlayButtonComponent.extend({
 	title: 'Play a random Radio4000 channel [⌨ r]',
 
-	click() {
-		get(this, 'player.playRandomChannel').perform();
-	}
-});
+	clickTask: task(function * () {
+		yield this.get('player.playRandomChannel').perform()
+	})
+})

--- a/app/components/play-random-channel/component.js
+++ b/app/components/play-random-channel/component.js
@@ -1,8 +1,16 @@
 import PlayButtonComponent from 'radio4000/components/play-btn/component'
 import {task, timeout} from 'ember-concurrency'
+import {or} from 'ember-awesome-macros'
+import {computed} from '@ember/object'
 
 export default PlayButtonComponent.extend({
 	title: 'Play a random Radio4000 channel [⌨ r]',
+
+	// Slightly different logic here so that the button also reacts
+	// when the random channel task is running OUTSIDE of this component.
+	// Like when you press the "R" shortcut.
+	isRunning: or('player.playRandomChannel.isRunning', 'clickTask.isRunning'),
+	disabled: computed.reads('isRunning'),
 
 	clickTask: task(function * () {
 		yield this.get('player.playRandomChannel').perform()

--- a/app/components/play-random-channel/template.hbs
+++ b/app/components/play-random-channel/template.hbs
@@ -1,2 +1,7 @@
-<i>▶</i> <small>random channel</small>
+<i>▶</i>
+{{#if clickTask.isRunning}}
+	Tuning…
+{{else}}
+	{{if clickTask.performCount "Play another radio" "Start listening"}}
+{{/if}}
 {{yield}}

--- a/app/components/play-random-channel/template.hbs
+++ b/app/components/play-random-channel/template.hbs
@@ -1,7 +1,7 @@
 <i>▶</i>
-{{#if clickTask.isRunning}}
+{{#if isRunning}}
 	Tuning…
 {{else}}
-	{{if clickTask.performCount "Play another radio" "Start listening"}}
+	{{if player.isPlaying "Play another radio" "Start listening"}}
 {{/if}}
 {{yield}}

--- a/app/components/play-shuffle-btn/component.js
+++ b/app/components/play-shuffle-btn/component.js
@@ -13,19 +13,10 @@ export default PlayButtonComponent.extend({
 		return get(this, 'isPlaying') ? 'Play a new random track from "all" tracks in this radio channel' : 'Play this radio';
 	}),
 
-	click() {
-		if (get(this, 'isPlaying') === true) {
-			this.playRandomTrack();
-		} else {
-			this.playFirstTrack();
-		}
-	},
 
-	playRandomTrack() {
-		get(this, 'channel.tracks').then(tracks => {
-			const randomIndex = getRandomIndex(tracks);
-			const randomTrack = tracks.objectAt(randomIndex);
-			get(this, 'player').playTrack(randomTrack);
-		});
-	}
-});
+	clickTask: task(function * () {
+		const player = get(this, 'player')
+		const taskName = get(this, 'isPlaying') ? 'playRandomTrack' : 'playFirstTrack'
+		yield get(player, taskName).perform(get(this, 'channel'))
+	})
+})

--- a/app/components/play-shuffle-btn/component.js
+++ b/app/components/play-shuffle-btn/component.js
@@ -1,18 +1,19 @@
 import Ember from 'ember';
 import PlayButtonComponent from 'radio4000/components/play-btn/component';
-import {getRandomIndex} from 'radio4000/utils/random-helpers';
+import {task} from 'ember-concurrency'
+import {conditional} from 'ember-awesome-macros'
+import raw from 'ember-macro-helpers/raw'
 
 const {computed, get} = Ember;
 
-// Extends the play button with a different title and template
-
 export default PlayButtonComponent.extend({
-	attributeBindings: ['title'],
-	isPlaying: computed.alias('channel.isInPlayer'),
-	title: computed('isPlaying', function () {
-		return get(this, 'isPlaying') ? 'Play a new random track from "all" tracks in this radio channel' : 'Play this radio';
-	}),
+	isPlaying: computed.reads('channel.isInPlayer'),
 
+	title: conditional(
+		'isPlaying',
+		raw('Play a new random track from "all" tracks in this radio channel'),
+		raw('Play this radio')
+	),
 
 	clickTask: task(function * () {
 		const player = get(this, 'player')

--- a/app/components/play-shuffle-btn/component.js
+++ b/app/components/play-shuffle-btn/component.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import PlayButtonComponent from 'radio4000/components/play-btn/component';
-import {task} from 'ember-concurrency'
+import {task, timeout} from 'ember-concurrency'
 import {conditional} from 'ember-awesome-macros'
 import raw from 'ember-macro-helpers/raw'
 
@@ -19,5 +19,6 @@ export default PlayButtonComponent.extend({
 		const player = get(this, 'player')
 		const taskName = get(this, 'isPlaying') ? 'playRandomTrack' : 'playFirstTrack'
 		yield get(player, taskName).perform(get(this, 'channel'))
-	})
+		yield timeout(100) // average user fast-tapping is 140ms
+	}).drop()
 })

--- a/app/components/play-shuffle-btn/template.hbs
+++ b/app/components/play-shuffle-btn/template.hbs
@@ -1,9 +1,11 @@
-{{#if isPlaying}}
-	<i>⇢</i>
-	{{if showText 'Play another track'}}
-{{else}}
-	<i>▶</i>
-	{{if showText 'Listen'}}
-{{/if}}
+<i>
+		{{if isPlaying "⇢" "▶"}}
+{{!-- 	{{#if clickTask.isRunning}}
+		💽
+	{{else}}
+	{{/if}} --}}
+</i>
 
-{{if clickTask.isRunning "Loading…"}}
+{{#if showText}}
+	{{if isPlaying "Play another track" "Listen"}}
+{{/if}}

--- a/app/components/play-shuffle-btn/template.hbs
+++ b/app/components/play-shuffle-btn/template.hbs
@@ -1,7 +1,9 @@
 {{#if isPlaying}}
 	<i>⇢</i>
-	{{if showText 'New random track'}}
+	{{if showText 'Play another track'}}
 {{else}}
 	<i>▶</i>
 	{{if showText 'Listen'}}
 {{/if}}
+
+{{if clickTask.isRunning "Loading…"}}

--- a/app/components/play-shuffle-btn/template.hbs
+++ b/app/components/play-shuffle-btn/template.hbs
@@ -1,14 +1,12 @@
 <i>
 	{{if isPlaying "⇢" "▶"}}
-	{{#unless showText}}
-		<span class="PulseLoader animate-rotate {{if clickTask.isIdle "u-dn"}}"></span>
-	{{/unless}}
+	<span class="PulseLoader animate-rotate"></span>
 </i>
 
 {{#if showText}}
 	{{#if clickTask.isRunning}}
 		Loading
 	{{else}}
-		{{if isPlaying "Play another track" "Listen"}}
+		{{if isPlaying "Play another" "Listen"}}
 	{{/if}}
 {{/if}}

--- a/app/components/play-shuffle-btn/template.hbs
+++ b/app/components/play-shuffle-btn/template.hbs
@@ -1,8 +1,14 @@
 <i>
 	{{if isPlaying "⇢" "▶"}}
-	<span class="PulseLoader animate-rotate {{if clickTask.isIdle "u-dn"}}"></span>
+	{{#unless showText}}
+		<span class="PulseLoader animate-rotate {{if clickTask.isIdle "u-dn"}}"></span>
+	{{/unless}}
 </i>
 
 {{#if showText}}
-	{{if isPlaying "Play another track" "Listen"}}
+	{{#if clickTask.isRunning}}
+		Loading
+	{{else}}
+		{{if isPlaying "Play another track" "Listen"}}
+	{{/if}}
 {{/if}}

--- a/app/components/play-shuffle-btn/template.hbs
+++ b/app/components/play-shuffle-btn/template.hbs
@@ -1,9 +1,6 @@
 <i>
-		{{if isPlaying "⇢" "▶"}}
-{{!-- 	{{#if clickTask.isRunning}}
-		💽
-	{{else}}
-	{{/if}} --}}
+	{{if isPlaying "⇢" "▶"}}
+	<span class="PulseLoader animate-rotate {{if clickTask.isIdle "u-dn"}}"></span>
 </i>
 
 {{#if showText}}

--- a/app/index.html
+++ b/app/index.html
@@ -54,8 +54,6 @@
 				width: 90%;
 				text-align: center;
 				transform: translateY(-50%);
-				-webkit-transform: translateY(-50%);
-				-moz-transform: translateY(-50%);
 			}
 			.DummyApp .Logo { display: block; }
 			.DummyApp p {

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -61,6 +61,10 @@ export default Service.extend({
 		this.playTrack(tracks.get('lastObject'))
 	}).drop(),
 
+	/**
+	 * Events from <radio4000-player>
+	 */
+
 	onTrackChanged(event) {
 		// set channels as active/inactive/add-to-history
 		if (event.previousTrack.channel !== event.track.channel) {
@@ -105,6 +109,10 @@ export default Service.extend({
 		}).then(channel => this.updateChannelHistory(channel));
 	},
 
+	/**
+	 * Listening history
+	 */
+
 	// add a channel to the History of played channels
 	updateChannelHistory(channel) {
 		const settings = get(this, 'session.currentUser.settings');
@@ -131,29 +139,6 @@ export default Service.extend({
 			settings.save();
 		});
 	},
-
-	/*
-		 Play random channel
-	 */
-	playRandomChannel: task(function * () {
-		const store = get(this, 'store')
-		let channels = store.peekAll('channel')
-
-		// Find a random channel with an optional request.
-		if (channels.get('length') < 15) {
-			channels = yield store.findAll('channel')
-		}
-		const channel = channels.objectAt(getRandomIndex(channels.content))
-
-		// If the channel doesn't have many tracks, choose another.
-		const tracks = yield channel.get('tracks')
-		if (tracks.length < 2) {
-			get(this, 'playRandomChannel').perform()
-			return
-		}
-
-		this.playTrack(tracks.get('lastObject'))
-	}).drop(),
 
 	/*
 		An export of a channel, its tracks and image in json format

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import {task} from 'ember-concurrency';
-
 import {getRandomIndex} from 'radio4000/utils/random-helpers';
 import {coverImg} from 'radio4000/helpers/cover-img';
 

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -47,17 +47,16 @@ export default Service.extend({
 		if (channels.get('length') < 15) {
 			channels = yield store.findAll('channel')
 		}
+
 		const channel = channels.objectAt(getRandomIndex(channels.content))
 
-		// If the channel doesn't have many tracks, choose another.
+		// Run again if channel has few tracks
 		const tracks = yield channel.get('tracks')
-		if (tracks.length < 2) {
+		const fewTracks = tracks.length < 5
+		if (fewTracks) {
 			get(this, 'playRandomChannel').perform()
 			return
 		}
-
-		// yield timeout(2000)
-
 		this.playTrack(tracks.get('lastObject'))
 	}).drop(),
 

--- a/app/styles/base/_button.scss
+++ b/app/styles/base/_button.scss
@@ -247,15 +247,3 @@
 .Btn--map {
 	z-index: 2;
 }
-
-@keyframes shake-little{2%{transform:translate(0px, 0px) rotate(.5deg)}4%{transform:translate(0px, 1px) rotate(.5deg)}6%{transform:translate(0px, 0px) rotate(.5deg)}8%{transform:translate(0px, 0px) rotate(.5deg)}10%{transform:translate(0px, 0px) rotate(.5deg)}12%{transform:translate(1px, 0px) rotate(.5deg)}14%{transform:translate(1px, 1px) rotate(.5deg)}16%{transform:translate(1px, 1px) rotate(.5deg)}18%{transform:translate(1px, 0px) rotate(.5deg)}20%{transform:translate(0px, 0px) rotate(.5deg)}22%{transform:translate(0px, 0px) rotate(.5deg)}24%{transform:translate(0px, 1px) rotate(.5deg)}26%{transform:translate(1px, 0px) rotate(.5deg)}28%{transform:translate(1px, 1px) rotate(.5deg)}30%{transform:translate(1px, 0px) rotate(.5deg)}32%{transform:translate(1px, 1px) rotate(.5deg)}34%{transform:translate(0px, 1px) rotate(.5deg)}36%{transform:translate(0px, 1px) rotate(.5deg)}38%{transform:translate(1px, 1px) rotate(.5deg)}40%{transform:translate(0px, 1px) rotate(.5deg)}42%{transform:translate(1px, 1px) rotate(.5deg)}44%{transform:translate(0px, 1px) rotate(.5deg)}46%{transform:translate(0px, 0px) rotate(.5deg)}48%{transform:translate(1px, 0px) rotate(.5deg)}50%{transform:translate(0px, 1px) rotate(.5deg)}52%{transform:translate(1px, 0px) rotate(.5deg)}54%{transform:translate(0px, 0px) rotate(.5deg)}56%{transform:translate(0px, 0px) rotate(.5deg)}58%{transform:translate(0px, 0px) rotate(.5deg)}60%{transform:translate(0px, 0px) rotate(.5deg)}62%{transform:translate(0px, 1px) rotate(.5deg)}64%{transform:translate(0px, 1px) rotate(.5deg)}66%{transform:translate(1px, 1px) rotate(.5deg)}68%{transform:translate(1px, 1px) rotate(.5deg)}70%{transform:translate(1px, 0px) rotate(.5deg)}72%{transform:translate(1px, 0px) rotate(.5deg)}74%{transform:translate(1px, 0px) rotate(.5deg)}76%{transform:translate(0px, 0px) rotate(.5deg)}78%{transform:translate(1px, 1px) rotate(.5deg)}80%{transform:translate(1px, 1px) rotate(.5deg)}82%{transform:translate(0px, 1px) rotate(.5deg)}84%{transform:translate(1px, 0px) rotate(.5deg)}86%{transform:translate(0px, 1px) rotate(.5deg)}88%{transform:translate(1px, 0px) rotate(.5deg)}90%{transform:translate(0px, 1px) rotate(.5deg)}92%{transform:translate(0px, 1px) rotate(.5deg)}94%{transform:translate(0px, 1px) rotate(.5deg)}96%{transform:translate(1px, 0px) rotate(.5deg)}98%{transform:translate(0px, 1px) rotate(.5deg)}0%,100%{transform:translate(0, 0) rotate(0)}}
-
-.Btn--shake {
-	transform-origin: center center;
-	animation: shake-little 100ms ease-in-out infinite;
-	animation-play-state:paused;
-}
-
-.Btn--shake.is-running {
-	animation-play-state: running;
-}

--- a/app/styles/base/_button.scss
+++ b/app/styles/base/_button.scss
@@ -247,3 +247,15 @@
 .Btn--map {
 	z-index: 2;
 }
+
+@keyframes shake-little{2%{transform:translate(0px, 0px) rotate(.5deg)}4%{transform:translate(0px, 1px) rotate(.5deg)}6%{transform:translate(0px, 0px) rotate(.5deg)}8%{transform:translate(0px, 0px) rotate(.5deg)}10%{transform:translate(0px, 0px) rotate(.5deg)}12%{transform:translate(1px, 0px) rotate(.5deg)}14%{transform:translate(1px, 1px) rotate(.5deg)}16%{transform:translate(1px, 1px) rotate(.5deg)}18%{transform:translate(1px, 0px) rotate(.5deg)}20%{transform:translate(0px, 0px) rotate(.5deg)}22%{transform:translate(0px, 0px) rotate(.5deg)}24%{transform:translate(0px, 1px) rotate(.5deg)}26%{transform:translate(1px, 0px) rotate(.5deg)}28%{transform:translate(1px, 1px) rotate(.5deg)}30%{transform:translate(1px, 0px) rotate(.5deg)}32%{transform:translate(1px, 1px) rotate(.5deg)}34%{transform:translate(0px, 1px) rotate(.5deg)}36%{transform:translate(0px, 1px) rotate(.5deg)}38%{transform:translate(1px, 1px) rotate(.5deg)}40%{transform:translate(0px, 1px) rotate(.5deg)}42%{transform:translate(1px, 1px) rotate(.5deg)}44%{transform:translate(0px, 1px) rotate(.5deg)}46%{transform:translate(0px, 0px) rotate(.5deg)}48%{transform:translate(1px, 0px) rotate(.5deg)}50%{transform:translate(0px, 1px) rotate(.5deg)}52%{transform:translate(1px, 0px) rotate(.5deg)}54%{transform:translate(0px, 0px) rotate(.5deg)}56%{transform:translate(0px, 0px) rotate(.5deg)}58%{transform:translate(0px, 0px) rotate(.5deg)}60%{transform:translate(0px, 0px) rotate(.5deg)}62%{transform:translate(0px, 1px) rotate(.5deg)}64%{transform:translate(0px, 1px) rotate(.5deg)}66%{transform:translate(1px, 1px) rotate(.5deg)}68%{transform:translate(1px, 1px) rotate(.5deg)}70%{transform:translate(1px, 0px) rotate(.5deg)}72%{transform:translate(1px, 0px) rotate(.5deg)}74%{transform:translate(1px, 0px) rotate(.5deg)}76%{transform:translate(0px, 0px) rotate(.5deg)}78%{transform:translate(1px, 1px) rotate(.5deg)}80%{transform:translate(1px, 1px) rotate(.5deg)}82%{transform:translate(0px, 1px) rotate(.5deg)}84%{transform:translate(1px, 0px) rotate(.5deg)}86%{transform:translate(0px, 1px) rotate(.5deg)}88%{transform:translate(1px, 0px) rotate(.5deg)}90%{transform:translate(0px, 1px) rotate(.5deg)}92%{transform:translate(0px, 1px) rotate(.5deg)}94%{transform:translate(0px, 1px) rotate(.5deg)}96%{transform:translate(1px, 0px) rotate(.5deg)}98%{transform:translate(0px, 1px) rotate(.5deg)}0%,100%{transform:translate(0, 0) rotate(0)}}
+
+.Btn--shake {
+	transform-origin: center center;
+	animation: shake-little 100ms ease-in-out infinite;
+	animation-play-state:paused;
+}
+
+.Btn--shake.is-running {
+	animation-play-state: running;
+}

--- a/app/styles/components/_channel-card.scss
+++ b/app/styles/components/_channel-card.scss
@@ -15,6 +15,10 @@
 }
 
 // Little circle that indicates the channel is playing.
+.ChannelCard.is-active {
+	border-color: $primary-color;
+}
+
 .ChannelCard.is-active::before {
 	content: "";
 	display: block;

--- a/app/styles/components/_channel-card.scss
+++ b/app/styles/components/_channel-card.scss
@@ -72,48 +72,6 @@
 	right: 0;
 }
 
-.ChannelCard-overlayBtn {
-	position: absolute;
-	top: 0.3rem;
-	right: 0.3rem;
-}
-
-.ChannelCard-overlayBtn .Btn {
-	display: flex;
-	font-size: 1.4rem;
-	background: none;
-	font-size: 1.4rem;
-	border: 0;
-	border-radius: 50%;
-	padding: 0.6rem;
-	background: rgba(black, 0);
-	color: rgba(white, 0.8);
-	transition: background 200ms, transform 200ms $easing4;
-	transform: scale(0.95);
-
-	svg {
-		left: auto !important;
-		top: auto !important;
-	}
-
-	&:hover,
-	&.is-loading {
-		background: rgba(black, 0.4);
-		color: rgba(white, 1);
-		transform: scale(1);
-		border-radius: 50%;
-	}
-
-	&:active {
-		transform: scale(0.98);
-	}
-
-	&.is-loading {
-		transition-duration: 800ms;
-		background-color: $primary-color;
-	}
-}
-
 // Modifier
 .ChannelCard--text {
 	@include size-1;

--- a/app/styles/components/_channel-card.scss
+++ b/app/styles/components/_channel-card.scss
@@ -14,19 +14,19 @@
 	}
 }
 
-.ChannelCard.is-active {
-	&::before {
-		background-color: $primary-color;
-		position: absolute;
-		z-index: 1;
-		top: -0.4rem;
-		right: -0.4rem;
-		height: 1rem;
-		width: 1rem;
-		display: block;
-		content: "";
-		border-radius: 50%;
-	}
+// Little circle that indicates the channel is playing.
+.ChannelCard.is-active::before {
+	content: "";
+	display: block;
+	height: 1rem;
+	width: 1rem;
+	background-color: $primary-color;
+	border-radius: 50%;
+
+	position: absolute;
+	z-index: 1;
+	top: -0.4rem;
+	left: -0.4rem;
 }
 
 .ChannelCard-title,

--- a/app/styles/components/_loader.scss
+++ b/app/styles/components/_loader.scss
@@ -32,3 +32,35 @@
 .animate-rotate {
 	animation: animate-rotate 1333ms linear infinite;
 }
+
+.PulseLoader {
+	display: inline-block;
+	width: 1em;
+	height: 1em;
+	background-color: #333;
+	border-radius: 100%;
+	animation: sk-scaleout 1333ms infinite ease-in-out;
+
+	.Btn & {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		transition: opacity 200ms ease-in;
+	}
+}
+
+.PulseLoader.u-dn {
+	opacity: 0;
+}
+
+@keyframes sk-scaleout {
+	0% {
+		transform: scale(0);
+	}
+	100% {
+		transform: scale(1);
+		opacity: 0;
+	}
+}

--- a/app/styles/components/_loader.scss
+++ b/app/styles/components/_loader.scss
@@ -35,32 +35,33 @@
 
 .PulseLoader {
 	display: inline-block;
-	width: 1em;
-	height: 1em;
-	background-color: #333;
-	border-radius: 100%;
+	width: 1.5em;
+	height: 1.5em;
+	background-color: $gray;
+	border-radius: 50%;
 	animation: sk-scaleout 1333ms infinite ease-in-out;
 
 	.Btn & {
 		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		transition: opacity 200ms ease-in;
+		top: calc(50% - 0.75em);
+		left: calc(50% - 0.75em);
+		animation-play-state: paused;
+		visibility: hidden;
 	}
-}
 
-.PulseLoader.u-dn {
-	opacity: 0;
+	.Btn.is-running & {
+		animation-play-state: running;
+		visibility: visible;
+	}
 }
 
 @keyframes sk-scaleout {
 	0% {
 		transform: scale(0);
+		opacity: 0;
 	}
 	100% {
 		transform: scale(1);
-		opacity: 0;
+		opacity: 1;
 	}
 }

--- a/app/styles/components/_loader.scss
+++ b/app/styles/components/_loader.scss
@@ -7,10 +7,12 @@
 	color: $dark;
 	display: block;
 	align-self: center;
-  margin-left: 0.5rem;
-p {
-	margin: 0;
-}
+	margin-left: 0.5rem;
+
+	p {
+		margin: 0;
+	}
+
 	p + p {
 		margin-bottom: 0.5rem;
 	}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "autoprefixer": "^7.1.6",
     "broccoli-asset-rev": "^2.4.5",
-    "ember-async-button": "^1.0.2",
     "ember-awesome-macros": "^0.40.0",
     "ember-browserify": "^1.1.11",
     "ember-cli": "~2.16.2",

--- a/tests/integration/components/play-random-channel/component-test.js
+++ b/tests/integration/components/play-random-channel/component-test.js
@@ -1,11 +1,17 @@
-import {moduleForComponent, test} from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit'
+import hbs from 'htmlbars-inline-precompile'
+import Ember from 'ember'
 
-moduleForComponent('play-random-channel', 'Integration | Component | play random channel', {
-	integration: true
-});
+moduleForComponent(
+	'play-random-channel',
+	'Integration | Component | play random channel',
+	{
+		integration: true
+	}
+)
 
-test('it renders', function (assert) {
-	this.render(hbs`{{play-random-channel}}`);
+test('it renders', function(assert) {
+	this.register('service:session', Ember.Service.extend())
+	this.render(hbs`{{play-random-channel}}`)
 	assert.equal(1, 1)
-});
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,13 +2592,6 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-async-button@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ember-async-button/-/ember-async-button-1.0.2.tgz#c2d3575f9f464d710adc97152536449058040b96"
-  dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-htmlbars "^1.0.3"
-
 ember-awesome-macros@^0.40.0:
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/ember-awesome-macros/-/ember-awesome-macros-0.40.0.tgz#df7243b4b8552be30037006eaa74807f18501fbb"


### PR DESCRIPTION
The goal of this PR is to add an indicator to our play buttons while it's loading.

- play methods moved together in player:service as tasks
- `{{play-btn}}` is reused for `{{play-btn-shuffle}}` and `{{play-random-channel}}`
- because of that, they all have a `clickTask` available
- this `clickTask` abstracts away whichever task they actually call
- the class `is-running` is added to the buttons while the task is running/loading

**Questions**

How do we make it obvious that it is loading in each button? I tried some different things but it's not quite smooth yet.

It's a bit annoying that the focus outline-styles appear as you're tapping the button. It should only come on focus.

Anything else?

Preview: http://feature-play-buttons--radio4000.netlify.com/