### PR TITLE
Add link-hashtags helper

### DIFF
--- a/app/components/channel-card/template.hbs
+++ b/app/components/channel-card/template.hbs
@@ -13,7 +13,7 @@
 	}}
 </div>
 <p class="ChannelCard-body">
-	{{do-truncate channel.body 200}}
+	{{link-hashtags (do-truncate channel.body 200) channel.slug}}
 </p>
 
 {{#unless channel.canEdit}}

--- a/app/components/channel-header/template.hbs
+++ b/app/components/channel-header/template.hbs
@@ -50,7 +50,7 @@
 			{{/if}}
 		</p>
 		{{#if channel.body}}
-			<p class="Channel-description">{{{link-hashtags channel.body channel.slug}}}</p>
+			<p class="Channel-description">{{link-hashtags channel.body channel.slug}}</p>
 		{{/if}}
 		{{#if hasLinks}}
 			<p class="Channel-links">

--- a/app/components/channel-header/template.hbs
+++ b/app/components/channel-header/template.hbs
@@ -50,7 +50,7 @@
 			{{/if}}
 		</p>
 		{{#if channel.body}}
-			<p class="Channel-description">{{channel.body}}</p>
+			<p class="Channel-description">{{{link-hashtags channel.body channel.slug}}}</p>
 		{{/if}}
 		{{#if hasLinks}}
 			<p class="Channel-links">

--- a/app/helpers/link-hashtags.js
+++ b/app/helpers/link-hashtags.js
@@ -11,7 +11,7 @@ export function linkHashtags([string, slug]) {
 	}
 
 	let stringWithLinks = string
-		.replace(hashtagRegex, `$1<a href="${slug}/tracks?search=$2">$2</a>`)
+		.replace(hashtagRegex, `$1<a href="/${slug}/tracks?search=$2">$2</a>`)
 
 	// Ember doesn't understand # in the URL. Replacing "#" with "%23" works.
 	// link = encodeURIComponent(link)

--- a/app/helpers/link-hashtags.js
+++ b/app/helpers/link-hashtags.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'
 import {helper} from '@ember/component/helper'
-import {htmlSafe} from '@ember/string'
+import {htmlSafe, isHTMLSafe} from '@ember/string'
 
 // https://regex101.com/r/pJ4wC5/1
 const hashtagRegex = /(^|\s)(#[a-z\d-]+)/ig
@@ -8,6 +8,11 @@ const hashtagRegex = /(^|\s)(#[a-z\d-]+)/ig
 export function linkHashtags([string, slug]) {
 	if (!slug) {
 		return string
+	}
+
+	// Support use cases like {{link-hashtags (do-truncate "my-string" 20)}}
+	if (isHTMLSafe(string)) {
+		string = string.string
 	}
 
 	let stringWithLinks = string

--- a/app/helpers/link-hashtags.js
+++ b/app/helpers/link-hashtags.js
@@ -1,0 +1,19 @@
+import { helper } from '@ember/component/helper';
+
+// https://regex101.com/r/pJ4wC5/1
+const hashtagRegex = /(^|\s)(#[a-z\d-]+)/ig
+
+export function linkHashtags([string, slug]) {
+	if (!slug) return string
+
+	let href = `/${slug}/tracks?search=$2`
+	let link = string.replace(hashtagRegex, `$1<a href="${href}">$2</a>`)
+
+	// Ember doesn't understand # in the URL. Replacing "#" with "%23" works.
+	link = link.replace(/=#/gi, '=%23')
+
+	return link
+}
+
+export default helper(linkHashtags)
+

--- a/app/helpers/link-hashtags.js
+++ b/app/helpers/link-hashtags.js
@@ -4,13 +4,17 @@ import { helper } from '@ember/component/helper';
 const hashtagRegex = /(^|\s)(#[a-z\d-]+)/ig
 
 export function linkHashtags([string, slug]) {
-	if (!slug) return string
+	if (!slug) {
+		return string
+	}
 
 	let href = `/${slug}/tracks?search=$2`
 	let link = string.replace(hashtagRegex, `$1<a href="${href}">$2</a>`)
 
+	// link = encodeURIComponent(link)
+
 	// Ember doesn't understand # in the URL. Replacing "#" with "%23" works.
-	link = link.replace(/=#/gi, '=%23')
+	link = link.replace(/(=#)/gi, '=%23')
 
 	return link
 }

--- a/app/helpers/link-hashtags.js
+++ b/app/helpers/link-hashtags.js
@@ -1,4 +1,6 @@
-import { helper } from '@ember/component/helper';
+import Ember from 'ember'
+import {helper} from '@ember/component/helper'
+import {htmlSafe} from '@ember/string'
 
 // https://regex101.com/r/pJ4wC5/1
 const hashtagRegex = /(^|\s)(#[a-z\d-]+)/ig
@@ -8,16 +10,18 @@ export function linkHashtags([string, slug]) {
 		return string
 	}
 
-	let href = `/${slug}/tracks?search=$2`
-	let link = string.replace(hashtagRegex, `$1<a href="${href}">$2</a>`)
-
-	// link = encodeURIComponent(link)
+	let stringWithLinks = string
+		.replace(hashtagRegex, `$1<a href="${slug}/tracks?search=$2">$2</a>`)
 
 	// Ember doesn't understand # in the URL. Replacing "#" with "%23" works.
-	link = link.replace(/(=#)/gi, '=%23')
+	// link = encodeURIComponent(link)
+	stringWithLinks = stringWithLinks.replace(/(=#)/gi, '=%23')
 
-	return link
+	// Make sure result is html safe.
+	Ember.Handlebars.Utils.escapeExpression(stringWithLinks)
+
+	// And "mark" it as safe.
+	return htmlSafe(stringWithLinks)
 }
 
 export default helper(linkHashtags)
-

--- a/tests/integration/helpers/link-hashtags-test.js
+++ b/tests/integration/helpers/link-hashtags-test.js
@@ -1,3 +1,4 @@
+import {linkHashtags} from 'radio4000/helpers/link-hashtags'
 import { moduleForComponent, test } from 'ember-qunit'
 import hbs from 'htmlbars-inline-precompile'
 
@@ -5,18 +6,14 @@ moduleForComponent('link-hashtags', 'helper:link-hashtags', {
 	integration: true
 })
 
-test('without slug it just returns the original string', function(assert) {
+test('without slug it returns original string', function(assert) {
 	this.set('inputValue', '1234 #cool')
 	this.render(hbs`{{link-hashtags inputValue}}`)
 
 	assert.equal(this.$().text().trim(), '1234 #cool')
 })
 
-test('with a slug it transforms hashtags to links', function(assert) {
-	this.set('inputValue', 'hey #cool right')
-	this.set('slugValue', '200ok')
-	this.render(hbs`{{link-hashtags inputValue slugValue}}`)
-
-	assert.equal(this.$().text().trim(), 'hey <a href="/200ok/tracks?search=%23cool">#cool</a> right')
+test('with slug it transforms hashtags to links', function(assert) {
+	const result = linkHashtags(['1234 #cool', '200ok'])
+	assert.equal(result.string, '1234 <a href="200ok/tracks?search=%23cool">#cool</a>')
 })
-

--- a/tests/integration/helpers/link-hashtags-test.js
+++ b/tests/integration/helpers/link-hashtags-test.js
@@ -15,5 +15,5 @@ test('without slug it returns original string', function(assert) {
 
 test('with slug it transforms hashtags to links', function(assert) {
 	const result = linkHashtags(['1234 #cool', '200ok'])
-	assert.equal(result.string, '1234 <a href="200ok/tracks?search=%23cool">#cool</a>')
+	assert.equal(result.string, '1234 <a href="/200ok/tracks?search=%23cool">#cool</a>')
 })

--- a/tests/integration/helpers/link-hashtags-test.js
+++ b/tests/integration/helpers/link-hashtags-test.js
@@ -1,0 +1,22 @@
+import { moduleForComponent, test } from 'ember-qunit'
+import hbs from 'htmlbars-inline-precompile'
+
+moduleForComponent('link-hashtags', 'helper:link-hashtags', {
+	integration: true
+})
+
+test('without slug it just returns the original string', function(assert) {
+	this.set('inputValue', '1234 #cool')
+	this.render(hbs`{{link-hashtags inputValue}}`)
+
+	assert.equal(this.$().text().trim(), '1234 #cool')
+})
+
+test('with a slug it transforms hashtags to links', function(assert) {
+	this.set('inputValue', 'hey #cool right')
+	this.set('slugValue', '200ok')
+	this.render(hbs`{{link-hashtags inputValue slugValue}}`)
+
+	assert.equal(this.$().text().trim(), 'hey <a href="/200ok/tracks?search=%23cool">#cool</a> right')
+})
+


### PR DESCRIPTION
Adds a `{{link-hashtags}}` that can be used to link hashtags to a track search.

So instead of

```
{{channel.body}}
```

you would do

```
{{link-hashtags channel.body channel.slug}}
```

It hardcodes the links as normal `<a>` but Ember seems to catch them anyway. For now I only added it to the channel-header component.