### PR TITLE
remove bookmarklet from fetching title

### DIFF
--- a/app/components/bookmarklet-link/template.hbs
+++ b/app/components/bookmarklet-link/template.hbs
@@ -2,6 +2,6 @@
 	class="Btn Btn--important Bookmarklet"
 	data-slug="{{slug}}"
 	title="Drag me to your bookmarks"
-	href="javascript:(function() {window.open('https://radio4000.com/add?url='+encodeURIComponent(location.href)+'&title='+encodeURIComponent(document.title))})();">
+	href="javascript:(function() {window.open('https://radio4000.com/add?url='+encodeURIComponent(location.href))})();">
 	{{yield}}
 </a>


### PR DESCRIPTION
Just realized that Youtube changed their SEO strategy, affecting our bookmarklet.

We used to pass the track URL and the title, but they have added `- Youtube` to every of their title, affecting all our Bookmarklet users.

it is actually a quick fix, but a major pain, since every one having the old bookmarklet is getting annoyed.

