### PR TITLE
Fix/channel edit slug

### DIFF
--- a/app/mixins/validate-slug.js
+++ b/app/mixins/validate-slug.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-import { task } from 'ember-concurrency'
+import {task} from 'ember-concurrency'
 import reservedUrls from 'radio4000/utils/reserved-urls'
 import randomText from 'radio4000/utils/random-text'
 import clean from 'radio4000/utils/clean'
@@ -18,17 +18,19 @@ export default Ember.Mixin.create({
 		const slugIsReserved = reservedUrls.any(
 			reservedSlug => reservedSlug === slug
 		)
-		if (slugIsReserved) {
-			throw new Error(`The slug "${slug}" is reserved`)
-		}
 
 		// Check if it is taken by another channel.
 		const query = yield this.store.query('channel', {
 			orderBy: 'slug',
 			equalTo: slug
 		})
-		if (query.get('firstObject')) {
+		const slugIsTaken = Boolean(query.get('firstObject'))
+
+		if (slugIsReserved || slugIsTaken) {
 			throw new Error(`The slug "${slug}" is already taken`)
+			return false
 		}
+
+		return true
 	})
 })

--- a/app/mixins/validate-slug.js
+++ b/app/mixins/validate-slug.js
@@ -28,7 +28,6 @@ export default Ember.Mixin.create({
 
 		if (slugIsReserved || slugIsTaken) {
 			throw new Error(`The slug "${slug}" is already taken`)
-			return false
 		}
 
 		return true

--- a/app/settings/channel/index/controller.js
+++ b/app/settings/channel/index/controller.js
@@ -38,9 +38,15 @@ export default Controller.extend(ValidateSlug, {
 		}
 
 		// Merge changes (props) onto the channel.
-		if (props.title) channel.set('title', props.title)
-		if (props.body) channel.set('body', props.body)
-		if (props.link) channel.set('link', props.link)
+		if (props.title) {
+			channel.set('title', props.title)
+		}
+		if (props.body) {
+			channel.set('body', props.body)
+		}
+		if (props.link) {
+			channel.set('link', props.link)
+		}
 
 		// Validate the model.
 		const isValid = channel.get('validations.isValid')

--- a/app/settings/channel/index/controller.js
+++ b/app/settings/channel/index/controller.js
@@ -1,16 +1,16 @@
 import Ember from 'ember'
-import Controller from '@ember/controller';
-import {get, set} from '@ember/object'
+import Controller from '@ember/controller'
+import {get} from '@ember/object'
 import {task} from 'ember-concurrency'
 import clean from 'radio4000/utils/clean'
 import ValidateSlug from 'radio4000/mixins/validate-slug'
 
-const { debug } = Ember
+const {debug} = Ember
 
 export default Controller.extend(ValidateSlug, {
 	// Props is an object with changes to be merged onto the channel.
 	// If slug changed, it will be validated and on success we transition the URL.
-	saveChannelDetails: task(function*(props) {
+	saveChannelDetails: task(function * (props) {
 		const messages = get(this, 'flashMessages')
 		const channel = get(this, 'model')
 
@@ -51,13 +51,6 @@ export default Controller.extend(ValidateSlug, {
 		try {
 			yield channel.save()
 			messages.success('Saved channel')
-
-			// We have to transition if the slug changed. Otherwise reloading is a 404.
-			if (slugChanged) {
-				set(this, 'initialSlug', channel.get('slug'))
-				debug('refreshing because slug changed')
-				this.transitionToRoute('channel.edit', channel.get('slug'))
-			}
 		} catch (err) {
 			messages.warning(`Sorry, we couldn't save your radio.`)
 			throw new Error(err)

--- a/app/settings/channel/index/controller.js
+++ b/app/settings/channel/index/controller.js
@@ -22,11 +22,11 @@ export default Controller.extend(ValidateSlug, {
 		}
 
 		// Check if slug changed (before merging)
-		const slug = channel.get('slug')
+		const oldSlug = channel.get('slug')
 		const newSlug = clean(props.slug)
-		const slugChanged = Boolean(props.slug) && newSlug !== slug
+		const slugChanged = Boolean(props.slug) && newSlug !== oldSlug
 
-		// Validate slug.
+		// Set new, cleaned slug if it is valid.
 		if (slugChanged) {
 			try {
 				yield get(this, 'validateSlug').perform(newSlug)
@@ -37,16 +37,11 @@ export default Controller.extend(ValidateSlug, {
 			}
 		}
 
-		// Merge changes (props) onto the channel.
-		if (props.title) {
-			channel.set('title', props.title)
-		}
-		if (props.body) {
-			channel.set('body', props.body)
-		}
-		if (props.link) {
-			channel.set('link', props.link)
-		}
+		// Merge changes/props onto the channel (except slug)
+		delete props.slug
+		Object.keys(props).forEach(prop => {
+			channel.set(prop, props[prop])
+		})
 
 		// Validate the model.
 		const isValid = channel.get('validations.isValid')

--- a/app/settings/channel/index/route.js
+++ b/app/settings/channel/index/route.js
@@ -1,4 +1,9 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
+	deactivate() {
+		// Clear any unsaved changes.
+		this.currentModel.rollbackAttributes()
+		this._super(...arguments)
+	}
 });

--- a/app/settings/channel/index/template.hbs
+++ b/app/settings/channel/index/template.hbs
@@ -4,19 +4,24 @@
 			<label>Cover image</label>
 		</p>
 		{{#if model.coverImage}}
-		<figure style="max-width: 100px">
-			{{channel-cover src=model.coverImage.src}}
-		</figure>
-		<button class="Btn Btn--small" title="To change your image, you'll need to delete this one first" {{action "deleteImage"}}>
-			Delete image
-		</button>
-		{{else}} {{cloudinary-upload cloudName='radio4000' unsignedUploadPreset='tc44ivjo' didUpload=(action "saveImage")}} {{/if}}
+			<figure style="max-width: 100px">
+				{{channel-cover src=model.coverImage.src}}
+			</figure>
+			<button class="Btn Btn--small" title="To change your image, you'll need to delete this one first" {{action "deleteImage"}}>
+				Delete image
+			</button>
+		{{else}}
+			{{cloudinary-upload cloudName='radio4000' unsignedUploadPreset='tc44ivjo' didUpload=(action "saveImage")}}
+		{{/if}}
 	</div>
 </section>
 
 <section class="Section">
 	<div class="Container">
-		{{channel-edit-details channel=(readonly model) submitTask=saveChannelDetails onCancel=(action "goBack")}}
+		{{channel-edit-details
+			channel=(readonly model)
+			submitTask=saveChannelDetails
+			onCancel=(action "goBack")}}
 	</div>
 </section>
 

--- a/app/settings/channel/route.js
+++ b/app/settings/channel/route.js
@@ -1,13 +1,4 @@
 import UserChannelRoute from 'radio4000/routes/user-channel'
 
 export default UserChannelRoute.extend({
-	setupController(controller, model) {
-		controller.set('initialSlug', model.get('slug'))
-		this._super(...arguments)
-	},
-
-	deactivate() {
-		// Clear any unsaved changes.
-		this.currentModel.rollbackAttributes()
-	}
 })

--- a/app/styles/components/_flash-messages.scss
+++ b/app/styles/components/_flash-messages.scss
@@ -40,7 +40,7 @@
 }
 
 .alert-warning {
-	background-color: $purple;
+	background-color: $red;
 }
 
 .alert-danger {

--- a/app/utils/clean.js
+++ b/app/utils/clean.js
@@ -5,5 +5,11 @@
 // For something with actual tests, consider https://github.com/pid/speakingurl
 
 export default function clean(string) {
-	return string.trim().dasherize().replace(/[`~!@#$%^&*()_|+=?;:'",.<>{}[\]\\/]/gi, '');
+	if (!string) {
+		return ''
+	}
+	return string
+		.trim()
+		.dasherize()
+		.replace(/[`~!@#$%^&*()_|+=?;:'",.<>{}[\]\\/]/gi, '');
 }


### PR DESCRIPTION
Two things were broken:

1. We compared `if (props)` but `props` could be an empty object, which is `true`. This meant it would wrongly continue to try and validate slug.

2. Getting the initial slug from the model via the route didn't work so `slugChanged` was always true.

When you tap 'save' without any changes, it doesn't actually save but still I introduced a "Saved" notification. Felt better. Otherwise I wasn't sure if it was stuck saving.. 

Please test, try to change slug, try to change it to that of an existing channel or reserved route like `about` or `help`.

cc @hellerve 