### PR TITLE
Feature/shortcuts overlay

### DIFF
--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -1,5 +1,4 @@
 /* global document */
-import Ember from 'ember';
 import Component from '@ember/component'
 import {get, set} from '@ember/object'
 import { inject as service } from '@ember/service'

--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -1,8 +1,9 @@
 /* global document */
 import Ember from 'ember';
+import Component from '@ember/component'
+import {get, set} from '@ember/object'
 import { inject as service } from '@ember/service'
-
-const {Component, run, get, set} = Ember;
+import {run} from '@ember/runloop'
 
 export default Component.extend({
 	uiStates: service(),
@@ -17,6 +18,7 @@ export default Component.extend({
 		'uiStates.isPanelLeftVisible:is-panelLeftVisible',
 		'player.isPlaying:is-withPlayer:is-withoutPlayer'
 	],
+
 	isShowingModal: false,
 
 	didInsertElement() {
@@ -42,6 +44,9 @@ export default Component.extend({
 		},
 		closeModal() {
 			set(this, 'isShowingModal', false);
+		},
+		closeShortcutsModal() {
+			set(this, 'uiStates.showShortcutsModal', false)
 		},
 		saveTrack(trackProperties) {
 			return get(this, 'onSaveTrack')(trackProperties);

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -46,8 +46,9 @@
 		onClose=(action "closeShortcutsModal")
 	}}
 		<button class="Btn u-alignRight" {{action "closeShortcutsModal"}}>close</button>
-		<h3>Player shortcuts</h3>
-		<ul>
+		<h2>Keyboard shortcuts</h2>
+		<h3>Player</h3>
+		<ul class="KeyboardList">
 			<li><kbd>p</kbd> play/pause</li>
 			<li><kbd>n</kbd> play <strong>next</strong> track</li>
 			<li><kbd>s</kbd> <strong>s</strong>huffle current track selection</li>
@@ -56,10 +57,10 @@
 			<li><kbd>f</kbd> cycle through <strong>f</strong>ormats (default, fullscreen, minimized)</li>
 		</ul>
 
-		<h3>Go-to shortcuts</h3>
-		<p><small>These shortcuts are used to move around the website. First press the key <kbd>g</kbd>, then on the other key (you have a window of 500ms to press the second key).</small></p>
-		<ul>
-			<li><kbd>g</kbd><kbd>h</kbd> <strong>h</strong>ome</li>
+		<h3>Movement</h3>
+		<p><small>Use these to move around the webiste. First press the <kbd>g</kbd> key followed by the second key before 500ms.</small></p>
+		<ul class="KeyboardList">
+			<li><kbd>g</kbd><kbd>h</kbd> <strong>h</strong>omepage</li>
 			<li><kbd>g</kbd><kbd>r</kbd> <strong>r</strong>adios</li>
 			<li><kbd>g</kbd><kbd>m</kbd> <strong>m</strong>ap</li>
 			<li><kbd>g</kbd><kbd>y</kbd> history (y, as in your web-browser)</li>
@@ -67,9 +68,9 @@
 			<li><kbd>g</kbd><kbd>s</kbd> my favorite radios (s, as in starred)</li>
 			<li><kbd>g</kbd><kbd>t</kbd> my <strong>t</strong>racks</li>
 			<li><kbd>g</kbd><kbd>a</kbd> <strong>a</strong>dd track</li>
+			<li><kbd>g</kbd><kbd>,</kbd> settings</li>
 			<li><kbd>g</kbd><kbd>f</kbd> <strong>f</strong>eedback</li>
 			<li><kbd>g</kbd><kbd>c</kbd> <strong>c</strong>urrent channel being played</li>
-			<li><kbd>g</kbd><kbd>,</kbd> settings</li>
 			<li><kbd>g</kbd><kbd>x</kbd> track being played (<strong>x</strong>, as in a cross to locate the track/trax)</li>
 		</ul>
 	{{/modal-dialog}}

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -39,3 +39,37 @@
 		</div>
 	{{/modal-dialog}}
 {{/if}}
+
+{{#if uiStates.showShortcutsModal}}
+	{{#modal-dialog
+		clickOutsideToClose=true
+		onClose=(action "closeShortcutsModal")
+	}}
+		<button class="Btn u-alignRight" {{action "closeShortcutsModal"}}>close</button>
+		<h3>Player shortcuts</h3>
+		<ul>
+			<li><kbd>p</kbd> play/pause</li>
+			<li><kbd>n</kbd> play <strong>next</strong> track</li>
+			<li><kbd>s</kbd> <strong>s</strong>huffle current track selection</li>
+			<li><kbd>m</kbd> (un)<strong>m</strong>ute the volume</li>
+			<li><kbd>r</kbd> play a <strong>r</strong>andom radio channel</li>
+			<li><kbd>f</kbd> cycle through <strong>f</strong>ormats (default, fullscreen, minimized)</li>
+		</ul>
+
+		<h3>Go-to shortcuts</h3>
+		<p><small>These shortcuts are used to move around the website. First press the key <kbd>g</kbd>, then on the other key (you have a window of 500ms to press the second key).</small></p>
+		<ul>
+			<li><kbd>g</kbd><kbd>h</kbd> <strong>h</strong>ome</li>
+			<li><kbd>g</kbd><kbd>r</kbd> <strong>r</strong>adios</li>
+			<li><kbd>g</kbd><kbd>m</kbd> <strong>m</strong>ap</li>
+			<li><kbd>g</kbd><kbd>y</kbd> history (y, as in your web-browser)</li>
+			<li><kbd>g</kbd><kbd>i</kbd> my radio (i, as in I, me)</li>
+			<li><kbd>g</kbd><kbd>s</kbd> my favorite radios (s, as in starred)</li>
+			<li><kbd>g</kbd><kbd>t</kbd> my <strong>t</strong>racks</li>
+			<li><kbd>g</kbd><kbd>a</kbd> <strong>a</strong>dd track</li>
+			<li><kbd>g</kbd><kbd>f</kbd> <strong>f</strong>eedback</li>
+			<li><kbd>g</kbd><kbd>c</kbd> <strong>c</strong>urrent channel being played</li>
+			<li><kbd>g</kbd><kbd>x</kbd> track being played (<strong>x</strong>, as in a cross to locate the track/trax)</li>
+		</ul>
+	{{/modal-dialog}}
+{{/if}}

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -69,6 +69,7 @@
 			<li><kbd>g</kbd><kbd>a</kbd> <strong>a</strong>dd track</li>
 			<li><kbd>g</kbd><kbd>f</kbd> <strong>f</strong>eedback</li>
 			<li><kbd>g</kbd><kbd>c</kbd> <strong>c</strong>urrent channel being played</li>
+			<li><kbd>g</kbd><kbd>,</kbd> settings</li>
 			<li><kbd>g</kbd><kbd>x</kbd> track being played (<strong>x</strong>, as in a cross to locate the track/trax)</li>
 		</ul>
 	{{/modal-dialog}}

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -47,6 +47,10 @@
 	}}
 		<button class="Btn u-alignRight" {{action "closeShortcutsModal"}}>close</button>
 		<h2>Keyboard shortcuts</h2>
+
+		<ul class="KeyboardList">
+			<li>Press <kbd>?</kbd> to toggle this window.</li>
+		</ul>
 		<h3>Player</h3>
 		<ul class="KeyboardList">
 			<li><kbd>p</kbd> play/pause</li>

--- a/app/components/app-root/template.hbs
+++ b/app/components/app-root/template.hbs
@@ -48,9 +48,6 @@
 		<button class="Btn u-alignRight" {{action "closeShortcutsModal"}}>close</button>
 		<h2>Keyboard shortcuts</h2>
 
-		<ul class="KeyboardList">
-			<li>Press <kbd>?</kbd> to toggle this window.</li>
-		</ul>
 		<h3>Player</h3>
 		<ul class="KeyboardList">
 			<li><kbd>p</kbd> play/pause</li>
@@ -76,6 +73,18 @@
 			<li><kbd>g</kbd><kbd>f</kbd> <strong>f</strong>eedback</li>
 			<li><kbd>g</kbd><kbd>c</kbd> <strong>c</strong>urrent channel being played</li>
 			<li><kbd>g</kbd><kbd>x</kbd> track being played (<strong>x</strong>, as in a cross to locate the track/trax)</li>
+		</ul>
+
+		<ul class="KeyboardList">
+			<li>
+				<small>
+					Press <kbd>?</kbd> to toggle this window.
+					Something missing?
+					<span {{action "closeShortcutsModal"}}>
+						{{link-to "Ask for it!" "feedback"}}
+					</span>
+				</small>
+			</li>
 		</ul>
 	{{/modal-dialog}}
 {{/if}}

--- a/app/components/aside-left/component.js
+++ b/app/components/aside-left/component.js
@@ -13,6 +13,9 @@ export default Component.extend({
 	actions: {
 		addTrack(trackModel) {
 			get(this, 'onClick')(trackModel);
+		},
+		openShortcutsModal() {
+			this.set('uiStates.showShortcutsModal', true)
 		}
 	}
 });

--- a/app/components/aside-left/template.hbs
+++ b/app/components/aside-left/template.hbs
@@ -61,10 +61,13 @@
 		<small>
 			<a href="https://support.internet4000.com/radio4000" target="_blank" rel="noopener" title="Support with Radio4000">
 				Help &rarr;
-			</a><br>
+			</a>
+			<br>
 			{{#link-to "feedback" title="Let us know what you have in mind! [⌨ g f]"}}
 				Send feedback
 			{{/link-to}}
+			<br>
+			<button class="NonBtn NonBtn--link" {{action "openShortcutsModal"}}>Keyboard shortcuts</button>
 		</small>
 	</footer>
 </div>

--- a/app/components/aside-left/template.hbs
+++ b/app/components/aside-left/template.hbs
@@ -67,7 +67,7 @@
 				Send feedback
 			{{/link-to}}
 			<br>
-			<button class="NonBtn NonBtn--link" {{action "openShortcutsModal"}}>Keyboard shortcuts</button>
+			<button class="NonBtn NonBtn--link" {{action "openShortcutsModal"}} title="Show keyboard shortcut [⌨  ?]">Keyboard shortcuts</button>
 		</small>
 	</footer>
 </div>

--- a/app/components/modal-dialog/component.js
+++ b/app/components/modal-dialog/component.js
@@ -1,27 +1,20 @@
-/* eslint ember/closure-actions:0 */
-import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
-import Ember from 'ember'
+import {on} from '@ember/object/evented'
+import ModalDialog from 'ember-modal-dialog/components/modal-dialog'
+import {EKMixin as EmberKeyboardMixin, keyDown} from 'ember-keyboard'
 
-const {$} = Ember
-
-export default ModalDialog.extend({
-	// Change the default value to use overlay.
+export default ModalDialog.extend(EmberKeyboardMixin, {
 	translucentOverlay: true,
 
-	didInsertElement() {
-		this._super()
+	init() {
+		this._super(...arguments)
 
-		// Close modal on ESC.
-		$('body').on('keyup.modal-dialog', e => {
-			if (e.keyCode === 27) {
-				this.sendAction('close');
-			}
-		});
+		this.set('keyboardActivated', true)
 	},
 
-	// Remove custom events.
-	willDestroyElement() {
-		this._super()
-		$('body').off('keyup.modal-dialog')
-	}
-});
+	closeOnEsc: on(keyDown('Escape'), function() {
+		if (this.get('onClose')) {
+			this.get('onClose')()
+			this.set('keyboardActivated', false)
+		}
+	})
+})

--- a/app/mixins/keyboard-shortcuts-global.js
+++ b/app/mixins/keyboard-shortcuts-global.js
@@ -100,6 +100,9 @@ export default Mixin.create(EKMixin, {
 	gotoFeedback: on(keyUp('KeyF'), function() {
 		this.goingTo('feedback')
 	}),
+	toggleShortcutsModal: on(keyUp('shift+Slash'), function() {
+		this.toggleProperty('uiStates.showShortcutsModal')
+	}),
 
 	// go `I`
 	gotoMyRadio: on(keyUp('KeyI'), function() {

--- a/app/mixins/keyboard-shortcuts-global.js
+++ b/app/mixins/keyboard-shortcuts-global.js
@@ -100,6 +100,9 @@ export default Mixin.create(EKMixin, {
 	gotoFeedback: on(keyUp('KeyF'), function() {
 		this.goingTo('feedback')
 	}),
+	goToSettings: on(keyUp('Comma'), function() {
+		this.goingTo('settings')
+	}),
 	toggleShortcutsModal: on(keyUp('shift+Slash'), function() {
 		this.toggleProperty('uiStates.showShortcutsModal')
 	}),

--- a/app/services/ui-states.js
+++ b/app/services/ui-states.js
@@ -5,6 +5,9 @@ import Cookies from 'npm:js-cookie';
 const {Service, computed, get, set, on} = Ember;
 
 export default Service.extend({
+	// Logic for showing keyboard shortcuts modal
+	showShortcutsModal: false,
+
 	// Set the format to 0 for mini, 1 for normal or 2 for max
 	format: 1,
 	isMinimized: computed.equal('format', 0),

--- a/app/styles/base/_button.scss
+++ b/app/styles/base/_button.scss
@@ -255,8 +255,8 @@
 /* keyboard "button" */
 .ember-modal-dialog kbd {
   display: inline-block;
-  padding: 3px 5px;
-  font: 11px monospace;
+	padding: 0 5px 4px;
+	font: 13px monospace;
 	background-color: $superlightgray;
   border: solid 1px #d1d5da;
   border-radius: $border-radius;

--- a/app/styles/base/_button.scss
+++ b/app/styles/base/_button.scss
@@ -239,6 +239,10 @@
 	}
 }
 
+.NonBtn--link {
+	text-decoration: underline;
+}
+
 /*
 	Button for the map
 	hover the fullscreen map
@@ -247,3 +251,15 @@
 .Btn--map {
 	z-index: 2;
 }
+
+/* keyboard "button" */
+.ember-modal-dialog kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font: 11px monospace;
+	background-color: $superlightgray;
+  border: solid 1px #d1d5da;
+  border-radius: $border-radius;
+  box-shadow: inset 0 -1px 0 #c6cbd1;
+}
+

--- a/app/styles/components/_list.scss
+++ b/app/styles/components/_list.scss
@@ -69,3 +69,19 @@
 		color: $gray;
 	}
 }
+
+.KeyboardList {
+	padding-left: 0;
+
+	li {
+		margin-bottom: 0.2em;
+	}
+
+	li::before {
+		display: none;
+	}
+
+	li kbd:last-of-type {
+		margin-right: 0.5em;
+	}
+}

--- a/app/styles/components/_modal-dialog.scss
+++ b/app/styles/components/_modal-dialog.scss
@@ -12,3 +12,16 @@
 div.ember-modal-overlay.translucent {
 	background-color: hsla(0, 0%, 20%, 0.6);
 }
+
+/* spacing between shortcuts */
+.ember-modal-dialog li {
+  margin-bottom: 0.2em;
+
+	// remove default list arrow
+	&::before {
+		display: none;
+	}
+}
+.ember-modal-dialog li kbd:last-of-type {
+  margin-right: 1em;
+}

--- a/app/styles/components/_modal-dialog.scss
+++ b/app/styles/components/_modal-dialog.scss
@@ -6,6 +6,8 @@
 	border-radius: $border-radius;
 	width: calc(100% - 2rem);
 	max-width: 500px;
+	max-height: 95vh;
+	overflow: auto;
 }
 
 // Set background for ember-modals
@@ -13,15 +15,3 @@ div.ember-modal-overlay.translucent {
 	background-color: hsla(0, 0%, 20%, 0.6);
 }
 
-/* spacing between shortcuts */
-.ember-modal-dialog li {
-  margin-bottom: 0.2em;
-
-	// remove default list arrow
-	&::before {
-		display: none;
-	}
-}
-.ember-modal-dialog li kbd:last-of-type {
-  margin-right: 1em;
-}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-keyboard": "^2.3.0",
     "ember-leaflet": "^3.0.14",
     "ember-load-initializers": "^1.0.0",
-    "ember-modal-dialog": "^2.3.0",
+    "ember-modal-dialog": "^3.0.0-beta.0",
     "ember-page-title": "^4.0.3",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3154,7 +3154,7 @@ ember-href-to@^1.15.1:
     ember-cli-babel "^6.8.2"
     ember-router-service-polyfill "^1.0.2"
 
-ember-ignore-children-helper@^1.0.0:
+ember-ignore-children-helper@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ember-ignore-children-helper/-/ember-ignore-children-helper-1.0.1.tgz#f7c4aa17afb9c5685e1d4dcdb61c7b138ca7cdc3"
   dependencies:
@@ -3226,15 +3226,15 @@ ember-maybe-import-regenerator@^0.1.5:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-modal-dialog@^2.3.0:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/ember-modal-dialog/-/ember-modal-dialog-2.4.4.tgz#d35d2a89af7fdd05038c9b5f31732edb8551a418"
+ember-modal-dialog@^3.0.0-beta.0:
+  version "3.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/ember-modal-dialog/-/ember-modal-dialog-3.0.0-beta.0.tgz#0d6a566bf5f29fe9923ea3b92107c13c681b61ee"
   dependencies:
-    ember-cli-babel "^6.8.2"
+    ember-cli-babel "^6.12.0"
     ember-cli-htmlbars "^2.0.1"
     ember-cli-version-checker "^2.1.0"
-    ember-ignore-children-helper "^1.0.0"
-    ember-wormhole "^0.5.1"
+    ember-ignore-children-helper "^1.0.1"
+    ember-wormhole "^0.5.4"
 
 ember-page-title@^4.0.3:
   version "4.0.3"
@@ -3374,7 +3374,7 @@ ember-wormhole@0.5.3:
     ember-cli-babel "^6.8.2"
     ember-cli-htmlbars "^2.0.1"
 
-ember-wormhole@^0.5.1, ember-wormhole@^0.5.2:
+ember-wormhole@^0.5.2, ember-wormhole@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.4.tgz#968e80f093494f4aed266e750afa63919c61383d"
   dependencies:


### PR DESCRIPTION
This adds an overview of all shortcuts that you can quickly open from anywhere. My hope is that more will see it and take advantage of all the shortcuts this way!

You toggle it with either the `?` key (as on github etc) or with a button in the sidebar footer.

Also added a `g,` shortcut to go to the new settings page.

<img width="967" alt="screen shot 2018-07-04 at 21 07 19" src="https://user-images.githubusercontent.com/184567/42291791-45378b4c-7fce-11e8-8368-5b24d395560a.png">

The list of shortcuts is now duplicated across the help center and this modal. It'll be annoying to have to update both. But also useful as some might still prefer to have a link.