### PR TITLE
feat: add notification on track when its media is not available

### DIFF
--- a/app/components/track-contextual/template.hbs
+++ b/app/components/track-contextual/template.hbs
@@ -17,5 +17,11 @@
 		<optgroup label="Manage">
 			<option value="editTrack">Edit</option>
 		</optgroup>
+		{{#if track.mediaNotAvailable}}
+			<optgroup label="Suggestions">
+				<option value="editTrack">-> Fix broken media URL</option>
+			</optgroup>
+		{{/if}}
 	{{/if}}
+
 </select>

--- a/app/components/track-edit/component.js
+++ b/app/components/track-edit/component.js
@@ -15,6 +15,10 @@ export default TrackFormComponent.extend({
 
 	disableSubmit: computed.oneWay('track.validations.isInvalid'),
 
+	youtubeSearchUrl: computed('track.title', function() {
+		return `https://www.youtube.com/results?search_query=${this.get('track.title')}`
+	}),
+
 	submitTask: task(function * (event) {
 		event.preventDefault()
 		yield get(this, 'track.update').perform()

--- a/app/components/track-edit/component.js
+++ b/app/components/track-edit/component.js
@@ -37,6 +37,5 @@ export default TrackFormComponent.extend({
 	setMediaAvailable: task(function * (event) {
 		event.preventDefault()
 		set(this, 'track.mediaNotAvailable', false)
-		get(this, 'submitTask').perform(event)
 	}).drop()
 })

--- a/app/components/track-edit/component.js
+++ b/app/components/track-edit/component.js
@@ -4,6 +4,7 @@ import TrackFormComponent from 'radio4000/components/track-form/component'
 
 const {
 	get,
+	set,
 	computed} = Ember
 
 export default TrackFormComponent.extend({
@@ -31,5 +32,11 @@ export default TrackFormComponent.extend({
 		yield get(this, 'track.delete').perform()
 		get(this, 'flashMessages').success('Track deleted')
 		yield get(this, 'onDelete')()
+	}).drop(),
+
+	setMediaAvailable: task(function * (event) {
+		event.preventDefault()
+		set(this, 'track.mediaNotAvailable', false)
+		get(this, 'submitTask').perform(event)
 	}).drop()
 })

--- a/app/components/track-edit/component.js
+++ b/app/components/track-edit/component.js
@@ -36,6 +36,6 @@ export default TrackFormComponent.extend({
 
 	setMediaAvailable: task(function * (event) {
 		event.preventDefault()
-		set(this, 'track.mediaNotAvailable', false)
+		yield set(this, 'track.mediaNotAvailable', false)
 	}).drop()
 })

--- a/app/components/track-edit/template.hbs
+++ b/app/components/track-edit/template.hbs
@@ -13,7 +13,15 @@
 {{/form-group}}
 
 {{#if track.mediaNotAvailable}}
-	<p>This link seems to be broken, <a href={{youtubeSearchUrl}} target="_blank" rel="noopener">find a new one</a>!</p>
+	<p>
+		<a href={{track.url}} target="_blank" rel="noopener">This link</a> seems to be broken, <a href={{youtubeSearchUrl}} target="_blank" rel="noopener">find a new one</a>!
+		<button
+			class="Btn Btn--small"
+			title="Signal that this link is not really broken, maybe just unavailable temporarily (ex: in the country you are currently)."
+			onclick={{perform setMediaAvailable}}>
+			No problem
+		</button>
+	</p>
 {{/if}}
 
 {{#form-group

--- a/app/components/track-edit/template.hbs
+++ b/app/components/track-edit/template.hbs
@@ -14,12 +14,13 @@
 
 {{#if track.mediaNotAvailable}}
 	<p>
-		<a href={{track.url}} target="_blank" rel="noopener">This link</a> seems to be broken, <a href={{youtubeSearchUrl}} target="_blank" rel="noopener">find a new one</a>!
+		This <a href={{track.url}} target="_blank" rel="noopener">URL</a> seems to be broken.<br>
+		<a href={{youtubeSearchUrl}} target="_blank" rel="noopener">Find a new one</a> or
 		<button
 			class="Btn Btn--small"
-			title="Signal that this link is not really broken, maybe just unavailable temporarily (ex: in the country you are currently)."
+			title="Signal that the link is ok and maybe just unavailable temporarily (ex: in the country you are currently)."
 			onclick={{perform setMediaAvailable}}>
-			No problem
+			ignore
 		</button>
 	</p>
 {{/if}}
@@ -49,7 +50,7 @@
 			<button
 					onclick={{perform submitTask}}
 					type="submit"
-					class="Btn"
+					class="Btn Btn--primary"
 					title="Save the track"
 				  disabled={{submitDisabled}}>
 				{{if submitTask.isIdle "Save" "Saving…"}}

--- a/app/components/track-edit/template.hbs
+++ b/app/components/track-edit/template.hbs
@@ -49,9 +49,9 @@
 			<button
 					onclick={{perform submitTask}}
 					type="submit"
-					class="Btn Btn--primary"
+					class="Btn"
 					title="Save the track"
-					disabled={{submitTask.isRunning}}>
+				  disabled={{submitDisabled}}>
 				{{if submitTask.isIdle "Save" "Saving…"}}
 			</button>
 

--- a/app/components/track-edit/template.hbs
+++ b/app/components/track-edit/template.hbs
@@ -1,8 +1,8 @@
 {{#form-group
-	model=track
-	valuePath="url"
-	label="URL"
-	hint="Paste in the URL of a YouTube video" as |value|}}
+		 model=track
+		 valuePath="url"
+		 label="URL"
+		 hint="Paste in the URL of a YouTube video" as |value|}}
 	{{focus-input
 			type="url"
 			value=value
@@ -11,6 +11,10 @@
 			autoFocus=true
 			autoSelect=true}}
 {{/form-group}}
+
+{{#if track.mediaNotAvailable}}
+	<p>This link seems to be broken, <a href={{youtubeSearchUrl}} target="_blank" rel="noopener">find a new one</a>!</p>
+{{/if}}
 
 {{#form-group
 	model=track

--- a/app/components/track-form/component.js
+++ b/app/components/track-form/component.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import config from 'radio4000/config/environment';
 import youtubeUrlToId from 'radio4000/utils/youtube-url-to-id';
+import {fetchTitle} from 'radio4000/utils/youtube-api';
 import {task, timeout} from 'ember-concurrency';
 
-const {Component, debug, get, set, observer} = Ember;
+const {Component, get, set, observer} = Ember;
 
 export default Component.extend({
 	tagName: 'form',
@@ -45,17 +45,10 @@ export default Component.extend({
 
 	fetchTitle: task(function * () {
 		yield timeout(250); // throttle
-		const track = get(this, 'track');
-		const ytid = track.get('ytid');
-		const url = `https://www.googleapis.com/youtube/v3/videos?id=${ytid}&key=${config.youtubeApiKey}&fields=items(id,snippet(title))&part=snippet`;
-		const response = yield fetch(url);
-		const data = yield response.json();
-		if (!data.items.length) {
-			debug('Could not find title for track');
-			return;
-		}
-		const title = data.items[0].snippet.title;
-		track.set('title', title);
+		const track = get(this, 'track')
+		const ytid = track.get('ytid')
+		let title = yield fetchTitle(ytid)
+		track.set('title', title)
 	}).restartable(),
 
 	submitTask: task(function * () {

--- a/app/components/track-form/component.js
+++ b/app/components/track-form/component.js
@@ -3,7 +3,7 @@ import youtubeUrlToId from 'radio4000/utils/youtube-url-to-id';
 import {fetchTitle} from 'radio4000/utils/youtube-api';
 import {task, timeout} from 'ember-concurrency';
 
-const {Component, get, set, observer} = Ember;
+const {Component, get, set, observer, computed} = Ember;
 
 export default Component.extend({
 	tagName: 'form',
@@ -41,6 +41,10 @@ export default Component.extend({
 			track.set('ytid', newid);
 			get(this, 'fetchTitle').perform();
 		}
+	}),
+
+	submitDisabled: computed('track.hasDirtyAttributes', 'submitTask', function() {
+		return !this.get('track.hasDirtyAttributes') || this.get('submitTask.isRunning')
 	}),
 
 	fetchTitle: task(function * () {

--- a/app/components/track-item/component.js
+++ b/app/components/track-item/component.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'
 
-const { Component, get, set, inject } = Ember
+const { Component, get, set, inject, computed } = Ember
 
 export default Component.extend({
 	player: inject.service(),
@@ -12,13 +12,16 @@ export default Component.extend({
 		'track.liveInCurrentPlayer:Track--live',
 		'track.playedInCurrentPlayer:Track--played',
 		'track.finishedInCurrentPlayer:Track--finished',
-		'track.mediaNotAvailable:Track--mediaNotAvailable'
+		'mediaNotAvailable:Track--mediaNotAvailable'
 	],
 
 	attributeBindings: [
 		'track.ytid:data-pid',
 		'track.id:data-track-id'
 	],
+
+	canEdit: computed.reads('track.channel.canEdit'),
+	mediaNotAvailable: computed.and('track.mediaNotAvailable', 'canEdit'),
 
 	actions: {
 		onEdit(track) {

--- a/app/components/track-item/component.js
+++ b/app/components/track-item/component.js
@@ -11,7 +11,8 @@ export default Component.extend({
 		// 	'isCurrent',
 		'track.liveInCurrentPlayer:Track--live',
 		'track.playedInCurrentPlayer:Track--played',
-		'track.finishedInCurrentPlayer:Track--finished'
+		'track.finishedInCurrentPlayer:Track--finished',
+		'track.mediaNotAvailable:Track--mediaNotAvailable'
 	],
 
 	attributeBindings: [

--- a/app/components/track-item/template.hbs
+++ b/app/components/track-item/template.hbs
@@ -5,7 +5,7 @@
 
 {{track-contextual
 	track=track
-	canEdit=track.channel.canEdit
+	canEdit=canEdit
 	onEdit=(action "onEdit")
 	onCopyTrack=(action "copyTrack")}}
 

--- a/app/components/x-playback/component.js
+++ b/app/components/x-playback/component.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 // 1- comment out the following `import`
 // 2- comment in the `script` tag in the `template.hbs`
 // cheers
-// import 'npm:radio4000-player';
+import 'npm:radio4000-player';
 
 const {Component, get, inject, computed} = Ember;
 

--- a/app/components/x-playback/component.js
+++ b/app/components/x-playback/component.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 // 1- comment out the following `import`
 // 2- comment in the `script` tag in the `template.hbs`
 // cheers
-import 'npm:radio4000-player';
+// import 'npm:radio4000-player';
 
 const {Component, get, inject, computed} = Ember;
 
@@ -24,15 +24,21 @@ export default Component.extend({
 		const options = {passive: false}
 		player.addEventListener('trackChanged', event => this.onTrackChanged(event), options)
 		player.addEventListener('trackEnded', event => this.onTrackEnded(event), options)
+		player.addEventListener('mediaNotAvailable', event => this.onMediaNotAvailable(event), options)
 		player.addEventListener('channelChanged', event => this.onChannelChanged(event), options)
 	},
 
+	/* events */
 	onTrackChanged(event) {
 		get(this, 'player').onTrackChanged(event.detail[0]);
 	},
 
 	onTrackEnded(event) {
 		get(this, 'player').onTrackEnded(event.detail[0]);
+	},
+
+	onMediaNotAvailable(event) {
+		get(this, 'player').onMediaNotAvailable(event.detail[0]);
 	},
 
 	actions: {

--- a/app/components/x-playback/template.hbs
+++ b/app/components/x-playback/template.hbs
@@ -7,7 +7,7 @@
 		track-id={{track.id}}
 		title="Radio4000 player. [⌨ g c = current channel] [⌨ g x = curent track]"
 	></radio4000-player>
-	{{!--  <script src="http://localhost:4002/radio4000-player.min.js"></script> --}}
+	<script src="http://localhost:4002/radio4000-player.min.js"></script>
 </div>
 
 <div class="Playback-layoutButtons">

--- a/app/components/x-playback/template.hbs
+++ b/app/components/x-playback/template.hbs
@@ -7,7 +7,7 @@
 		track-id={{track.id}}
 		title="Radio4000 player. [⌨ g c = current channel] [⌨ g x = curent track]"
 	></radio4000-player>
-	<script src="http://localhost:4002/radio4000-player.min.js"></script>
+	<!-- <script src="http://localhost:4002/radio4000-player.min.js"></script> -->
 </div>
 
 <div class="Playback-layoutButtons">

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -102,7 +102,7 @@ export default Model.extend(Validations, {
 
 		let mediaNotAvailable = yield !fetchTrackAvailability(ytid)
 
-		if(mediaNotAvailable) {
+		if (mediaNotAvailable) {
 			this.set('mediaNotAvailable', true)
 		} else {
 			this.set('mediaNotAvailable', false)

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -100,13 +100,8 @@ export default Model.extend(Validations, {
 
 		const ytid = this.get('ytid')
 
-		let mediaNotAvailable = yield !fetchTrackAvailability(ytid)
-
-		if (mediaNotAvailable) {
-			this.set('mediaNotAvailable', true)
-		} else {
-			this.set('mediaNotAvailable', false)
-		}
+		let isAvailable = yield fetchTrackAvailability(ytid)
+		this.set('mediaNotAvailable', !isAvailable)
 
 		yield this.updateYoutubeId();
 		yield this.save()

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -45,6 +45,10 @@ export default Model.extend(Validations, {
 	body: attr('string'),
 	ytid: attr('string'),
 
+	mediaNotAvailable: attr('boolean', {
+		defaultValue: false
+	}),
+
 	// relationships
 	channel: belongsTo('channel', {
 		async: true,

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -101,7 +101,8 @@ export default Service.extend({
 		get(this, 'store').findRecord('track', event.track.id)
 			.then(track => {
 				// only set media as not-available for track owner (for now)
-				if(channel.get('id') === track.get('channel.id')) {
+				const isOwner = channel.get('id') === track.get('channel.id')
+				if (isOwner) {
 					track.set('mediaNotAvailable', true);
 					track.save();
 				}

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -96,6 +96,13 @@ export default Service.extend({
 		});
 	},
 
+	onMediaNotAvailable(event) {
+		get(this, 'store').findRecord('track', event.track.id).then(track => {
+			track.set('mediaNotAvailable', true);
+			track.save();
+		});
+	},
+
 	channelChanged(previousChannelId, channelId) {
 		// set previous channel as not active
 		if (previousChannelId !== undefined) {

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -97,10 +97,15 @@ export default Service.extend({
 	},
 
 	onMediaNotAvailable(event) {
-		get(this, 'store').findRecord('track', event.track.id).then(track => {
-			track.set('mediaNotAvailable', true);
-			track.save();
-		});
+		let channel = this.get('session.currentUser.channels.firstObject')
+		get(this, 'store').findRecord('track', event.track.id)
+			.then(track => {
+				// only set media as not-available for track owner (for now)
+				if(channel.get('id') === track.get('channel.id')) {
+					track.set('mediaNotAvailable', true);
+					track.save();
+				}
+			});
 	},
 
 	channelChanged(previousChannelId, channelId) {

--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -63,6 +63,9 @@
 .Track--finished {
 	border-right-color: $green;
 }
+.Track--mediaNotAvailable {
+	border-right-color: $red;
+}
 
 .Track-title {
 	@extend %font-regular;

--- a/app/utils/youtube-api.js
+++ b/app/utils/youtube-api.js
@@ -23,7 +23,7 @@ const fetchYoutubeTrack = async (ytid, fields) => {
 
 const fetchTitle = async function (ytid) {
 	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet');
-	return data.snippet.title
+	return data && data.snippet.title
 }
 
 

--- a/app/utils/youtube-api.js
+++ b/app/utils/youtube-api.js
@@ -26,7 +26,6 @@ const fetchTitle = async function (ytid) {
 	return data && data.snippet.title
 }
 
-
 const fetchTrackAvailability = async function (ytid) {
 	// let data = await fetchYoutubeTrack(ytid, 'items(id,status)&part=status')
 	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet');

--- a/app/utils/youtube-api.js
+++ b/app/utils/youtube-api.js
@@ -29,7 +29,7 @@ const fetchTitle = async function (ytid) {
 const fetchTrackAvailability = async function (ytid) {
 	// let data = await fetchYoutubeTrack(ytid, 'items(id,status)&part=status')
 	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet');
-	return Boolean(data.snippet.title)
+	return Boolean(data && data.snippet.title)
 }
 
 export {fetchTitle, fetchTrackAvailability};

--- a/app/utils/youtube-api.js
+++ b/app/utils/youtube-api.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+import config from 'radio4000/config/environment';
+const {debug} = Ember;
+
+const fetchYoutubeTrack = async (ytid, fields) => {
+	if (!ytid) {
+		throw Error('You need to provide a youtube video to fetchYoutubeTrack')
+	}
+	if (!fields) {
+		fields = `items(id,snippet,contentDetails,statistics)&part=snippet,contentDetails,statistics`;
+	}
+
+	let rootUrl = `https://www.googleapis.com/youtube/v3/videos?key=${config.youtubeApiKey}`
+	let url = rootUrl + `&id=${ytid}&fields=${fields}`
+	let response = await fetch(url);
+	let data = await response.json();
+	if (!data.items.length) {
+		debug('Could not find title for track');
+		return;
+	}
+	return data.items[0]
+}
+
+const fetchTitle = async function (ytid) {
+	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet');
+	return data.snippet.title
+}
+
+
+const fetchTrackAvailability = async function (ytid) {
+	// let data = await fetchYoutubeTrack(ytid, 'items(id,status)&part=status')
+	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet');
+	return Boolean(data.snippet.title)
+}
+
+export {fetchTitle, fetchTrackAvailability};

--- a/app/utils/youtube-api.js
+++ b/app/utils/youtube-api.js
@@ -32,7 +32,7 @@ const fetchTrackAvailability = async function (ytid) {
 	// let data = await fetchYoutubeTrack(ytid, 'items(id,status)&part=status')
 	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet')
 
-	return !!data.items.length
+	return Boolean(data.items.length)
 }
 
 export {fetchTitle, fetchTrackAvailability};

--- a/app/utils/youtube-api.js
+++ b/app/utils/youtube-api.js
@@ -14,22 +14,25 @@ const fetchYoutubeTrack = async (ytid, fields) => {
 	let url = rootUrl + `&id=${ytid}&fields=${fields}`
 	let response = await fetch(url);
 	let data = await response.json();
-	if (!data.items.length) {
-		debug('Could not find title for track');
-		return;
-	}
-	return data.items[0]
+	return data
 }
 
 const fetchTitle = async function (ytid) {
 	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet');
-	return data && data.snippet.title
+
+	if (!data.items.length) {
+		debug('Could not find title for track');
+		return;
+	}
+
+	return data.items[0] && data.items[0].snippet.title
 }
 
 const fetchTrackAvailability = async function (ytid) {
 	// let data = await fetchYoutubeTrack(ytid, 'items(id,status)&part=status')
-	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet');
-	return Boolean(data && data.snippet.title)
+	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet')
+
+	return !!data.items.length
 }
 
 export {fetchTitle, fetchTrackAvailability};

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "emberfire": "^2.0.10",
     "js-cookie": "^2.2.0",
     "lazysizes": "^4.0.1",
-    "radio4000-player": "^0.5.1",
+    "radio4000-player": "^0.5.2",
     "torii": "^0.10.1",
     "youtube-regex": "^1.0.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6856,9 +6856,9 @@ qunit@^2.5.0:
     resolve "1.5.0"
     walk-sync "0.3.2"
 
-radio4000-player@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/radio4000-player/-/radio4000-player-0.5.1.tgz#848f4b8265cac27855cdf9d70e5a491a43af7375"
+radio4000-player@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/radio4000-player/-/radio4000-player-0.5.2.tgz#962610cba7b9e4a3d7d41d556c76e7a9af23a753"
   dependencies:
     document-register-element "^1.8.1"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Related PRs:
- https://github.com/internet4000/radio4000-player/pull/110
- merged https://github.com/internet4000/radio4000-api/pull/46


In this PR:

- [x] add event listener for `onMediaNotAvailable`
- [x] add property `track.mediaNotAvailable`
- [x] display a notification on `{{track-item}}`
- [x] add link for suggestion on how to fix this in tracks's contextual menu and `{{track-edit}}`
- [x] remove notification when track url has been updated
- [x] only update/save track with a changed `onMediaNotAvailable` if the current session is by the track owner (or update an other "public track model", which we don't have yet - ping @oskarrough https://github.com/internet4000/radio4000-api/pull/45 ) 
- [x] add check to youtube api to see if new url is available (but don't update the exisiting `track.title`)
- [x] the `no problem` button that sets a media as available is saving all track changes (we just want it to to set the track as available, not save body if it was changed?) 
- [x] switch back to loading player from npm

It's nice as it opens a nice patern for adding more providers such as Discogs or Bancamp links.

Maybe some feature above are for a v2. We have to take care that it does not become annoying.

# Future features

- add a `/settings/channel/tools` root with the possibility to hide the track edit suggestions
- add a `/tools` route with a `massTagEditor` and `massTrackEdit` and `massTrackUrlFix`