### PR TITLE
Fix old YouTube ID for availability check

### DIFF
--- a/app/models/track.js
+++ b/app/models/track.js
@@ -98,12 +98,12 @@ export default Model.extend(Validations, {
 			return
 		}
 
+		yield this.updateYoutubeId()
 		const ytid = this.get('ytid')
 
 		let isAvailable = yield fetchTrackAvailability(ytid)
 		this.set('mediaNotAvailable', !isAvailable)
 
-		yield this.updateYoutubeId();
 		yield this.save()
 	}).drop(),
 


### PR DESCRIPTION
When you edit a broken (not available) track URL to a working one it was not using the new YouTube ID to check for track availability.