### PR TITLE
Improve focus styles on tracks

### DIFF
--- a/app/components/track-contextual/template.hbs
+++ b/app/components/track-contextual/template.hbs
@@ -1,27 +1,28 @@
-<button class="Btn Btn--toggle Btn--text">
-	<span></span>
-	<span></span>
-	<span></span>
-</button>
-
-<select class="ContextualToggle-select" onchange={{ action 'handleSelect'}}>
-	<option disabled selected value style="display:none;">-</option>
-	<optgroup label="Share">
-		<option value="copyYoutubeURL">Copy YouTube URL</option>
-		<option value="copyR4URL">Copy Radio4000 URL</option>
-		{{#if session.currentUser.channels.firstObject.isPremium}}
-			<option value="copyTrackToRadio">Add to my radio</option>
-		{{/if}}
-	</optgroup>
-	{{#if canEdit}}
-		<optgroup label="Manage">
-			<option value="editTrack">Edit</option>
+<label>
+	<select class="ContextualToggle-select" onchange={{ action 'handleSelect'}}>
+		<option disabled selected value style="display:none;">-</option>
+		<optgroup label="Share">
+			<option value="copyYoutubeURL">Copy YouTube URL</option>
+			<option value="copyR4URL">Copy Radio4000 URL</option>
+			{{#if session.currentUser.channels.firstObject.isPremium}}
+				<option value="copyTrackToRadio">Add to my radio</option>
+			{{/if}}
 		</optgroup>
-		{{#if track.mediaNotAvailable}}
-			<optgroup label="Suggestions">
-				<option value="editTrack">-> Fix broken media URL</option>
+		{{#if canEdit}}
+			<optgroup label="Manage">
+				<option value="editTrack">Edit</option>
 			</optgroup>
+			{{#if track.mediaNotAvailable}}
+				<optgroup label="Suggestions">
+					<option value="editTrack">-> Fix broken media URL</option>
+				</optgroup>
+			{{/if}}
 		{{/if}}
-	{{/if}}
-
-</select>
+	</select>
+	<button class="Btn Btn--toggle Btn--text" tabindex="-1">
+		<span></span>
+		<span></span>
+		<span></span>
+		<span class="u-hiddenVisually">More</span>
+	</button>
+</label>

--- a/app/styles/components/_list.scss
+++ b/app/styles/components/_list.scss
@@ -38,12 +38,6 @@
 	flex: 1;
 	padding: 0.7rem 1rem 0.6rem 2rem;
 	text-decoration: none;
-
-	&:hover,
-	&:focus,
-	&:active {
-		text-decoration: none;
-	}
 }
 
 // Numbered list

--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -89,6 +89,7 @@
 
 .Track-contextual {
 	margin-left: auto;
+	margin-bottom: auto;
 
 	.Btn--toggle {
 		pointer-events: none;

--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -6,10 +6,7 @@
 	@include size-1;
 	display: flex;
 	position: relative;
-	overflow: hidden; // hide controls
 	border-bottom: 1px solid $lightgray;
-	box-shadow: 1px 0 0 $mediumlightgray;
-
 	// Empty border to avoid jumps when indicating state.
 	border-right: 2px solid transparent;
 
@@ -24,36 +21,42 @@
 		}
 	}
 
-	&:hover,
-	&:focus {
-		background-color: hsla(0, 100%, 100%, 0.3);
+	&:hover {
+		background-color: $superlightgray;
+	}
+}
+
+// When you focus the contextual <select>,
+// we actually use a button to indicate it.
+.ContextualToggle-select:focus ~ .Btn--toggle span {
+	background-color: black;
+}
+
+// Hidden purple dot.
+.Track--live::before {
+	display: block;
+	height: 0.7rem;
+	width: 0.7rem;
+	content: "";
+	border-radius: 50%;
+	background-color: $primary-color;
+
+	position: absolute;
+	top: 50%;
+	left: -0.5rem;
+	transform: translateY(-50%);
+
+	@media (min-width: $layout-s) {
+		left: 0.5rem;
 	}
 }
 
 .Track--live {
 	background-color: $white;
 
-	&:hover,
-	&:focus {
+	> a:hover,
+	> a:hover + .Track-contextual {
 		background-color: $white;
-	}
-
-	// Purple dot.
-	&::before {
-		background-color: $primary-color;
-		position: absolute;
-		top: 50%;
-		left: -0.5rem;
-		height: 0.75rem;
-		width: 0.75rem;
-		display: block;
-		content: "";
-		border-radius: 50%;
-		transform: translateY(-50%);
-
-		@media (min-width: $layout-s) {
-			left: 0.5rem;
-		}
 	}
 }
 
@@ -86,7 +89,10 @@
 
 .Track-contextual {
 	margin-left: auto;
-	align-self: flex-start;
+
+	.Btn--toggle {
+		pointer-events: none;
+	}
 }
 
 /**

--- a/app/styles/utilities/_displays.scss
+++ b/app/styles/utilities/_displays.scss
@@ -5,3 +5,14 @@
 .u-flex {
 	display: flex;
 }
+
+.u-hiddenVisually {
+	border: 0!important;
+	clip: rect(1px,1px,1px,1px)!important;
+	font-size: 1px!important;
+	height: 1px!important;
+	overflow: hidden!important;
+	padding: 0!important;
+	position: absolute!important;
+	width: 1px!important;
+}


### PR DESCRIPTION
This PR improves the keyboard accessibility of our track lists.

Before (https://radio4000.com/nomads)

1st tab: focus track
2nd tab: focus button (but can't open the select)
3rd tab: focus invisible select (but can't see that you focus it)

After (https://deploy-preview-255--radio4000.netlify.com/nomads)

1st tab: focus track
2nd tab: focus select (with fancy css so the button looks focused)

.. and a bit more visible focus styles.

I really wanted the contextual menu to open with `enter` press as well, but apparently that is not how the web works. You use `space`. People won't understand buuut that's how it is. Unless someone has an idea?

