### PR TITLE
feat: add purple border to toggle sidenav btn

### DIFF
--- a/app/styles/components/_aside.scss
+++ b/app/styles/components/_aside.scss
@@ -47,6 +47,7 @@
 		left: -3px;
 		z-index: 6;
 		opacity: 0.5;
+		border-color: $purple;
 
 		&:focus,
 		&:hover {

--- a/app/styles/components/_aside.scss
+++ b/app/styles/components/_aside.scss
@@ -42,12 +42,14 @@
 
 .Aside--left {
 	.Aside-toggleBtn {
+		font-size: 1.3rem;
 		position: fixed;
-		top: 2.1rem;
-		left: -3px;
+		top: 1.8rem;
+		left: -0.4rem;
 		z-index: 6;
 		opacity: 0.5;
 		border-color: $purple;
+
 
 		&:focus,
 		&:hover {

--- a/app/styles/components/_logo.scss
+++ b/app/styles/components/_logo.scss
@@ -6,7 +6,7 @@
 	transition: transform 300ms $easing2, background-color 200ms;
 	max-width: 7rem;
 	padding-top: 2.3rem;
-	padding-left: 2.3rem;
+	padding-left: 2.8rem;
 	user-select: none; // don't highlight
 	display: none;
 


### PR DESCRIPTION
Micro PR just to try and show the UI a bit more obviously, with minimal change.

It should help mobile users see the "sidenav button", to for example find the `add new track` button (which was a feed back from this weekend).

- makes the toggle nav button border color purple
- makes the button font-size slighly larger
- moves the logo position to fit visually