### PR TITLE
feat: change channel h1 to be underlined when it should be clicked (aka, outside of channel.index)

### DIFF
--- a/app/styles/base/_base.scss
+++ b/app/styles/base/_base.scss
@@ -38,9 +38,9 @@ a:hover {
 }
 
 h1 a {
-	text-decoration: none;
+	text-decoration: underline;
 	&.is-active {
-		text-decoration: underline;
+		text-decoration: none;
 	}
 }
 

--- a/app/styles/base/_base.scss
+++ b/app/styles/base/_base.scss
@@ -38,9 +38,16 @@ a:hover {
 }
 
 h1 a {
-	text-decoration: underline;
+	text-decoration: none;
+	border-bottom: 4px solid $black;
+	margin-bottom: 1.5rem;
+	transition: border-bottom-color 200ms ease-in-out;
 	&.is-active {
+		border-bottom-color: transparent;
+	}
+	&:hover {
 		text-decoration: none;
+		border-bottom-color: $text-color;
 	}
 }
 

--- a/app/styles/components/_manchet.scss
+++ b/app/styles/components/_manchet.scss
@@ -4,7 +4,7 @@
  */
 .Manchet {
 	@extend %Container;
-	margin-bottom: 1rem;
+	margin-bottom: 1.5rem;
 	display: flex;
 	flex-wrap: wrap;
 

--- a/app/styles/components/_tabs.scss
+++ b/app/styles/components/_tabs.scss
@@ -46,6 +46,9 @@
 		@extend %font-bold;
 		border-right-color: $primary-color;
 		background-color: $superlightgray;
+		.Muted {
+			font-weight: normal;
+		}
 	}
 	& small {
 		font-size: rem(9);


### PR DESCRIPTION
This PR only switches the decoration of the channel title, on a channel homepage, and its subpages.

Before, when the `channel.index` was active, the h1 title was underline, now it is not.

Before, when the `channel.sub-page` was active, the h1 title, was not underlined, now it is, because it means that the title can be clicked like a link to go back to the homepage.

This is very minor but I think it explains better how the channel page works, and it frees the homepage from an unecessary horizontal line, giving emphasis of the title's typography.
