### PR TITLE
Fix keyboard events on inputs

### DIFF
--- a/app/components/focus-input/component.js
+++ b/app/components/focus-input/component.js
@@ -1,6 +1,6 @@
-import Ember from 'ember'
-
-const { TextField, get } = Ember
+import TextField from '@ember/component/text-field'
+import {get} from '@ember/object'
+import {keyUp} from 'ember-keyboard'
 
 // http://emberjs.com/guides/cookbook/user_interface_and_interaction/focusing_a_textfield_after_its_been_inserted/
 
@@ -12,8 +12,9 @@ export default TextField.extend({
 	didInsertElement() {
 		this._super(...arguments)
 
-		// ember-keyboard prevents key-events when a TextField is focused.
-		// This reverses it so the parent modal can close on "Escape."
+		// ember-keyboard captures all keyboard events on TextField class,
+		// so they don't bubble up. We want to allow bubbling but only for "Escape",
+		// which closes modals.
 		this.set('keyboard.isPropagationEnabled', true)
 
 		if (get(this, 'autoFocus')) {
@@ -29,5 +30,11 @@ export default TextField.extend({
 		if (get(this, 'autoSelect')) {
 			this.element.select()
 		}
-	}
+	},
+
+	allowEscapeKeyOnly: Ember.on(keyUp(), function(event, emberKeyboardEvent) {
+		if (event.key !== 'Escape') {
+			emberKeyboardEvent.stopPropagation()
+		}
+	})
 })

--- a/app/components/focus-input/component.js
+++ b/app/components/focus-input/component.js
@@ -1,5 +1,6 @@
 import TextField from '@ember/component/text-field'
 import {get} from '@ember/object'
+import {on} from '@ember/object/evented'
 import {keyUp} from 'ember-keyboard'
 
 // http://emberjs.com/guides/cookbook/user_interface_and_interaction/focusing_a_textfield_after_its_been_inserted/
@@ -32,7 +33,7 @@ export default TextField.extend({
 		}
 	},
 
-	allowEscapeKeyOnly: Ember.on(keyUp(), function(event, emberKeyboardEvent) {
+	allowEscapeKeyOnly: on(keyUp(), function(event, emberKeyboardEvent) {
 		if (event.key !== 'Escape') {
 			emberKeyboardEvent.stopPropagation()
 		}

--- a/config/environment.js
+++ b/config/environment.js
@@ -48,6 +48,10 @@ module.exports = function(environment) {
 		pageTitle: {
 			separator: ' - ',
 			prepend: true
+		},
+
+		emberKeyboard: {
+			propagation: true
 		}
 	};
 


### PR DESCRIPTION
This a little bit annoying but my last "fix" accidently enabled ALL keyboard events to trigger inside inputs. What we want is only "Escape" to trigger. Hopefully there is a cleaner way to do this but I don't see it at the moment.