### PR TITLE
fix: webapp start_url in manifest json, from index.html to /

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Radio4000",
   "short_name": "Radio4000",
   "description": "Collect, curate, play and share your own radio channel",
-  "start_url": "index.html",
+  "start_url": "/",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#5d1ae6",


### PR DESCRIPTION
Saving r4 as bookmark to desktop (aka making r4 a webapp in practice) does not work, as it seems it is saving r4.com/index.html.

Trying to make to `start_url` to `/`