### PR TITLE
mvp for showing discogs when available on a track

### DIFF
--- a/app/components/track-contextual/component.js
+++ b/app/components/track-contextual/component.js
@@ -32,6 +32,10 @@ export default Component.extend({
 			const url = `https://radio4000.com/${slug}/${id}`;
 			this.copyURL(url);
 		},
+		copyDiscogsURL() {
+			const url = get(this, 'track.discogsUrl');
+			this.copyURL(url);
+		},
 		handleSelect(event) {
 			const el = event.target;
 			const value = el.options[el.selectedIndex].value;

--- a/app/components/track-contextual/template.hbs
+++ b/app/components/track-contextual/template.hbs
@@ -1,11 +1,14 @@
 <label>
 	<select class="ContextualToggle-select" onchange={{ action 'handleSelect'}}>
 		<option disabled selected value style="display:none;">-</option>
-		<optgroup label="Share">
-			<option value="copyYoutubeURL">Copy YouTube URL</option>
-			<option value="copyR4URL">Copy Radio4000 URL</option>
+		<optgroup label="Links">
 			{{#if session.currentUser.channels.firstObject.isPremium}}
 				<option value="copyTrackToRadio">Add to my radio</option>
+			{{/if}}
+			<option value="copyR4URL">Copy Radio4000 URL</option>
+			<option value="copyYoutubeURL">Copy YouTube URL</option>
+			{{#if track.discogsUrl}}
+				<option value="copyDiscogsURL">Copy Discogs URL</option>
 			{{/if}}
 		</optgroup>
 		{{#if canEdit}}

--- a/app/components/track-item/component.js
+++ b/app/components/track-item/component.js
@@ -12,7 +12,8 @@ export default Component.extend({
 		'track.liveInCurrentPlayer:Track--live',
 		'track.playedInCurrentPlayer:Track--played',
 		'track.finishedInCurrentPlayer:Track--finished',
-		'mediaNotAvailable:Track--mediaNotAvailable'
+		'mediaNotAvailable:Track--mediaNotAvailable',
+		'track.discogsUrl:Track--hasDiscogs'
 	],
 
 	attributeBindings: [

--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -7,8 +7,10 @@
 	display: flex;
 	position: relative;
 	border-bottom: 1px solid $lightgray;
-	// Empty border to avoid jumps when indicating state.
+	// Empty border to avoid jumps when indicating playback state.
 	border-right: 2px solid transparent;
+	// This border is for indicating track data state (discogs).
+	border-left: 2px solid transparent;
 
 	.icon-play {
 		position: absolute;
@@ -68,6 +70,9 @@
 }
 .Track--mediaNotAvailable {
 	border-right-color: $red;
+}
+.Track--hasDiscogs {
+	border-left-color: $yellow;
 }
 
 .Track-title {


### PR DESCRIPTION
This PR just shows when a Discogs release link is available on a track, in every radio track list.

It is a mvp and can be improved in a certain future.

Some hints:

- maybe we need to show a track detail page/overlay on which you can open the links instead of having to copy them (more natural)
- maybe on this same overlay we can make some api calls to Discogs and display some more data regarding the track (expensive api calls)
