### PR TITLE
add P for play current channel keyboard shortcut

### DIFF
--- a/app/mixins/keyboard-shortcuts-global.js
+++ b/app/mixins/keyboard-shortcuts-global.js
@@ -85,6 +85,13 @@ export default Mixin.create(EKMixin, {
 			get(this, 'player.playRandomChannel').perform()
 		}
 	}),
+
+	playCurrentChannel: on(keyUp('shift+KeyP'), function() {
+		if (get(this, 'onChannelRoute')) {
+			this.get('player.playFirstTrack').perform(this.modelFor('channel'))
+		}
+	}),
+
 	gotoChannelHome: on(keyUp('KeyH'), function() {
 		this.goingTo('channel.index', this.modelFor('channel'))
 	}),


### PR DESCRIPTION
When the user is on a channel route, `P` will play its first track.

Thought it would be nice to have the same behavior has Play, then play random, but also the user can do that with keyboard shortcuts for the player already. So maybe some other time if the need is there.