### PR TITLE
fix contextual menu being too wide

### DIFF
--- a/app/styles/components/_track.scss
+++ b/app/styles/components/_track.scss
@@ -84,6 +84,8 @@
 .Track-contextual {
 	margin-left: auto;
 	margin-bottom: auto;
+	position: relative;
+	overflow: hidden;
 
 	.Btn--toggle {
 		pointer-events: none;


### PR DESCRIPTION
this should fix the contextual menu select on track being too wide compare to the size of its parent container.