### PR TITLE
Fix /explore search+menu bug

### DIFF
--- a/app/channels/explore/template.hbs
+++ b/app/channels/explore/template.hbs
@@ -13,7 +13,7 @@
 						Search
 					</span>
 					{{jets-search
-							contentTag=".Grid"
+							contentTag=".JetsSearchContainer"
 							content=filteredChannels
 							value=search
 							title="Search all radio channels (title and description); Usage: `word1 word2 ...` will find channels that have all words at the same time"
@@ -70,7 +70,7 @@
 			{{/btn-group}}
 		</div>
 
-		<div class="Grid">
+		<div class="Grid JetsSearchContainer">
 			{{#vertical-collection manipulatedList
 				estimateHeight=333
 				bufferSize=8


### PR DESCRIPTION
The inline search on /explore works by filtering the DOM through the "Jets" plugin.

Our problem was that we filter elements inside the selector `.Grid`, which is also used in the menu overlay. So when the menu is empty after searching, it was because Jets is also filtering that………

Fixed by using a unique class name instead.

Fixes #342 