### PR TITLE
make channel's body links (tags) bold instead of underline

### DIFF
--- a/app/styles/components/_channel-card.scss
+++ b/app/styles/components/_channel-card.scss
@@ -33,6 +33,13 @@
 	color: $dark;
   // Ensure very long words do not mess up the layout.
 	word-break: break-word;
+	a {
+		text-decoration: none;
+		font-weight: bold;
+		&:hover {
+			background-color: $lightgray;
+		}
+	}
 }
 
 .ChannelCard-controls {

--- a/app/styles/components/_channel.scss
+++ b/app/styles/components/_channel.scss
@@ -35,6 +35,14 @@
 	flex: 1;
 	padding: 1.5rem 1.5rem 0;
 
+	a {
+		text-decoration: none;
+		font-weight: bold;
+		&:hover {
+			background-color: $lightgray;
+		}
+	}
+
 	@media (min-width: $layout-s) {
 		padding-top: 2rem;
 	}


### PR DESCRIPTION
visual improvement? I think it is nicer to look at