### PR TITLE
map before explore

### DIFF
--- a/app/components/aside-channels/template.hbs
+++ b/app/components/aside-channels/template.hbs
@@ -7,17 +7,17 @@
 	{{/link-to}}
 
 	{{#link-to
-		"channels.explore"
-		title="Explore all radios on Radio4000 [⌨ g r]"
-		class="Tabs-item"}}
-		Explore
-	{{/link-to}}
-
-	{{#link-to
 		"channels.map"
 		title="Visualize radio on planet earth's world map [⌨ g m]"
 		class="Tabs-item"}}
 		Map
+	{{/link-to}}
+
+	{{#link-to
+			 "channels.explore"
+			 title="Explore all radios on Radio4000 [⌨ g r]"
+			 class="Tabs-item"}}
+		Explore
 	{{/link-to}}
 </div>
 


### PR DESCRIPTION
moved map before explore on /channels aside navigation.

- map loads, faster, so our user should see a fast loading page after explore (if they follow the logic pattern of clicking item number two)
- I guess people looking for /explore don't really mind the extra 50px to click the btn
- there are still the quick search if you know where you want to go, and kbd shortcuts