### PR TITLE
Fix inputs wider than share box in webkit

### DIFF
--- a/app/styles/base/_button.scss
+++ b/app/styles/base/_button.scss
@@ -3,7 +3,6 @@
 	font-weight: bold;
 	align-items: center;
 	background-color: $superlightgray;
-	box-sizing: border-box; /* 1 */
 	cursor: pointer;
 	display: inline-block;
 	display: inline-flex;

--- a/app/styles/base/_form.scss
+++ b/app/styles/base/_form.scss
@@ -12,6 +12,7 @@
 textarea,
 .Btn,
 .select-css {
+	box-sizing: border-box;
 	@include size-1;
 	border: 1px solid rgba($gray, 0.4);
 	border-radius: $border-radius;


### PR DESCRIPTION
we set `box-sizing: border-box` on `html` and let all elements inherit it. but still, the inputs would have `content-box`. Don't know why. This seems to fix it.