### PR TITLE
Better fullscreen + dock player mode

### DIFF
--- a/app/channel/home/template.hbs
+++ b/app/channel/home/template.hbs
@@ -1,10 +1,14 @@
 <div class="Sections Sections--center">
 	<section class="Section">
 		<div class="Container Container--small">
-			{{#link-to "channel.player"}}
+			<h1 class="u-tc" title="Explore radio">
+				{{#link-to "channel"}}
+					{{model.title}}
+				{{/link-to}}
+			</h1>
+			{{#link-to "channel.player" title="Go to radio player"}}
 				{{channel-cover src=model.image alt=model.title size=1000}}
 			{{/link-to}}
-			<h1 class="u-tc">{{model.title}}</h1>
 		</div>
 	</section>
 

--- a/app/channel/home/template.hbs
+++ b/app/channel/home/template.hbs
@@ -1,10 +1,10 @@
 <div class="Sections Sections--center">
 	<section class="Section">
 		<div class="Container Container--small">
-			{{#link-to "channel"}}
+			{{#link-to "channel.player"}}
 				{{channel-cover src=model.image alt=model.title size=1000}}
 			{{/link-to}}
-		<h1>{{model.title}}</h1>
+			<h1 class="u-tc">{{model.title}}</h1>
 		</div>
 	</section>
 

--- a/app/channel/index/controller.js
+++ b/app/channel/index/controller.js
@@ -9,6 +9,8 @@ const {
 
 export default Controller.extend({
 	applicationController: inject.controller('application'),
+	uiStates: inject.service(),
+	player: inject.service(),
 
 	notExperienced: computed.not('model.channel.isExperienced'),
 	showWelcome: computed.and('notExperienced', 'model.channel.canEdit'),
@@ -20,6 +22,9 @@ export default Controller.extend({
 				newUrl: url,
 				showAddTrack: true
 			});
+		},
+		toggleDockedFormat() {
+			get(this, 'uiStates').toggleDockedFormat();
 		}
 	}
 });

--- a/app/channel/player/controller.js
+++ b/app/channel/player/controller.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Controller from '@ember/controller';
 
-const { inject, get } = Ember;
+const { inject } = Ember;
 
 export default Controller.extend({
 	player: inject.service()

--- a/app/channel/player/controller.js
+++ b/app/channel/player/controller.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import Controller from '@ember/controller';
+
+const { inject, get } = Ember;
+
+export default Controller.extend({
+	player: inject.service()
+});

--- a/app/channel/player/route.js
+++ b/app/channel/player/route.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import Route from '@ember/routing/route';
+
+const { inject, get } = Ember;
+
+export default Route.extend({
+	uiStates: inject.service(),
+
+	renderTemplate: function() {
+		this.render({
+			into: 'application'
+		});
+	},
+
+	activate() {
+		get(this, 'uiStates').toggleDockedFormat()
+	},
+	deactivate() {
+		if (get(this, 'uiStates.isDocked')) {
+			get(this, 'uiStates').toggleNormalFormat()
+		}
+	}
+});

--- a/app/channel/player/template.hbs
+++ b/app/channel/player/template.hbs
@@ -1,14 +1,16 @@
 {{#if player.currentTrack}}
 	{{#link-to 'channel' model class="ChannelScreen"}}
+		<div class="ChannelScreen-media"></div>
 	{{/link-to}}
 {{else}}
 	<div class="ChannelScreen">
-		{{play-shuffle-btn channel=model class="Btn--large Btn--text Channel-playback" showText=false}}
+		<div class="ChannelScreen-media"></div>
+		{{play-shuffle-btn channel=model showText=false class="Btn--large Btn--text Channel-playback"}}
 	</div>
 {{/if}}
 
 <style>
-	.ChannelScreen {
-		background-image: url({{cover-img model.image size=1000}});
+	.ChannelScreen-media {
+		background-image: url({{cover-img model.image size=600}});
 	}
 </style>

--- a/app/channel/player/template.hbs
+++ b/app/channel/player/template.hbs
@@ -3,7 +3,7 @@
 	{{/link-to}}
 {{else}}
 	<div class="ChannelScreen">
-		{{play-shuffle-btn channel=model class="Btn--large Channel-playback"}}
+		{{play-shuffle-btn channel=model class="Btn--large Btn--text Channel-playback" showText=false}}
 	</div>
 {{/if}}
 

--- a/app/channel/player/template.hbs
+++ b/app/channel/player/template.hbs
@@ -1,0 +1,14 @@
+{{#if player.currentTrack}}
+	{{#link-to 'channel' model class="ChannelScreen"}}
+	{{/link-to}}
+{{else}}
+	<div class="ChannelScreen">
+		{{play-shuffle-btn channel=model class="Btn--large Channel-playback"}}
+	</div>
+{{/if}}
+
+<style>
+	.ChannelScreen {
+		background-image: url({{cover-img model.image format='jpg' size=1200}});
+	}
+</style>

--- a/app/channel/player/template.hbs
+++ b/app/channel/player/template.hbs
@@ -9,6 +9,6 @@
 
 <style>
 	.ChannelScreen {
-		background-image: url({{cover-img model.image format='jpg' size=1200}});
+		background-image: url({{cover-img model.image size=1000}});
 	}
 </style>

--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -14,6 +14,7 @@ export default Component.extend({
 	classNameBindings: [
 		'uiStates.isMinimized',
 		'uiStates.isFullscreen:is-maximized',
+		'uiStates.isNormal:is-normal',
 		'uiStates.isPanelLeftVisible:is-panelLeftVisible',
 		'player.isPlaying:is-withPlayer:is-withoutPlayer'
 	],

--- a/app/components/app-root/component.js
+++ b/app/components/app-root/component.js
@@ -14,6 +14,7 @@ export default Component.extend({
 	classNameBindings: [
 		'uiStates.isMinimized',
 		'uiStates.isFullscreen:is-maximized',
+		'uiStates.isDocked:is-docked',
 		'uiStates.isNormal:is-normal',
 		'uiStates.isPanelLeftVisible:is-panelLeftVisible',
 		'player.isPlaying:is-withPlayer:is-withoutPlayer'

--- a/app/components/x-playback/component.js
+++ b/app/components/x-playback/component.js
@@ -47,6 +47,9 @@ export default Component.extend({
 		},
 		toggleFullscreenFormat() {
 			get(this, 'uiStates').toggleFullscreenFormat();
+		},
+		toggleDockedFormat() {
+			get(this, 'uiStates').toggleDockedFormat();
 		}
 	}
 });

--- a/app/components/x-playback/template.hbs
+++ b/app/components/x-playback/template.hbs
@@ -1,14 +1,5 @@
 <!-- Do you like this player? It's open source!
-	 github.com/internet4000/radio4000-player -->
-
-<div class="Playback-player">
-	<radio4000-player
-		autoplay="true"
-		r4-url="true"
-		track-id={{track.id}}
-	></radio4000-player>
-	<!-- <script src="http://localhost:4002/radio4000-player.min.js"></script> -->
-</div>
+		 github.com/internet4000/radio4000-player -->
 
 <div class="Playback-layoutButtons">
 	<button class="Btn Playback-fullscreen" {{action 'toggleFullscreenFormat'}} title="Toggle fullscreen player [⌨ f]">
@@ -17,4 +8,19 @@
 	<button class="Btn Playback-minimize" {{action 'toggleMinimizedFormat'}} title="Toggle minimized player [⌨ f]">
 		{{if uiStates.isMinimized '→' '↓'}}
 	</button>
+	{{#if uiStates.isDocked}}
+		<button class="Btn Playback-dock" {{action 'toggleDockedFormat'}} title="Dock player [⌨ f]">↔</button>
+	{{else}}
+		{{link-to '↔' 'channel.player' channel class="Btn Playback-dock"}}
+		<button class="Btn Playback-dock" {{action 'toggleDockedFormat'}} title="Dock player [⌨ f]">↔</button>
+	{{/if}}
+</div>
+
+<div class="Playback-player">
+	<radio4000-player
+		autoplay="true"
+		r4-url="true"
+		track-id={{track.id}}
+	></radio4000-player>
+	<!-- <script src="http://localhost:4002/radio4000-player.min.js"></script> -->
 </div>

--- a/app/router.js
+++ b/app/router.js
@@ -33,6 +33,7 @@ Router.map(function() {
 		this.route('play', function() {
 			this.route('random')
 		})
+		this.route('player');
 	})
 	this.authenticatedRoute('add')
 	this.authenticatedRoute('bookmarklet')

--- a/app/services/ui-states.js
+++ b/app/services/ui-states.js
@@ -99,6 +99,10 @@ export default Service.extend({
 		set(this, 'format', 2);
 	},
 	toggleDockedFormat() {
+		// if we're fullscreen, just go out
+		if (this.isPlayerFullscreen()) {
+			this.exitFullscreen()
+		}
 		if (get(this, 'isDocked')) {
 			this.toggleNormalFormat()
 			return;

--- a/app/services/ui-states.js
+++ b/app/services/ui-states.js
@@ -37,6 +37,9 @@ export default Service.extend({
 				this.toggleNormalFormat()
 			}
 		}
+		if (get(this, 'isDocked')) {
+			return this.toggleDockedFormat()
+		}
 	},
 
 	init() {
@@ -68,6 +71,10 @@ export default Service.extend({
 
 		if (get(this, 'isNormal')) {
 			this.toggleFullscreenFormat()
+			return;
+		}
+		if (get(this, 'isMediumScreen')) {
+			this.toggleMinimizedFormat()
 			return;
 		}
 		set(this, 'format', 1);

--- a/app/services/ui-states.js
+++ b/app/services/ui-states.js
@@ -68,8 +68,10 @@ export default Service.extend({
 			this.exitFullscreen()
 		}
 		if (get(this, 'isMinimized')) {
-			this.toggleNormalFormat()
-			return;
+			if (!get(this, 'isMediumScreen')) {
+				this.toggleNormalFormat()
+				return;
+			}
 		}
 		set(this, 'format', 0);
 	},

--- a/app/services/ui-states.js
+++ b/app/services/ui-states.js
@@ -57,7 +57,9 @@ export default Service.extend({
 		return document.fullscreen
 	},
 	exitFullscreen() {
-		document.exitFullscreen()
+		if (this.isPlayerFullscreen()) {
+			document.exitFullscreen()
+		}
 	},
 
 	// actions used by player UI buttons

--- a/app/services/ui-states.js
+++ b/app/services/ui-states.js
@@ -8,6 +8,15 @@ export default Service.extend({
 	// Logic for showing keyboard shortcuts modal
 	showShortcutsModal: false,
 
+	init() {
+		this._super(...arguments)
+		document.addEventListener('fullscreenchange', () => {
+			if (!document.fullscreenElement && get(this, 'isFullscreen')) {
+				this.toggleFullscreenFormat()
+			}
+		});
+	},
+
 	// all formats
 	isMinimized: computed.equal('format', 0),
 	isNormal: computed.equal('format', 1),
@@ -22,7 +31,9 @@ export default Service.extend({
 	}),
 	cycleFormat() {
 		// if we're fullscreen, just go out
-		this.isPlayerFullscreen() && this.exitFullscreen()
+		if (this.isPlayerFullscreen()) {
+			this.exitFullscreen()
+		}
 
 		if (get(this, 'isNormal')) {
 			return this.toggleMinimizedFormat()
@@ -42,14 +53,6 @@ export default Service.extend({
 		}
 	},
 
-	init() {
-		document.addEventListener('fullscreenchange', () => {
-			if (!document.fullscreenElement && get(this, 'isFullscreen')) {
-				this.toggleFullscreenFormat()
-			}
-		});
-	},
-
 	isPlayerFullscreen() {
 		return document.fullscreen
 	},
@@ -59,7 +62,9 @@ export default Service.extend({
 
 	// actions used by player UI buttons
 	toggleMinimizedFormat() {
-		this.isPlayerFullscreen() && this.exitFullscreen()
+		if (this.isPlayerFullscreen()) {
+			this.exitFullscreen()
+		}
 		if (get(this, 'isMinimized')) {
 			this.toggleNormalFormat()
 			return;
@@ -67,7 +72,9 @@ export default Service.extend({
 		set(this, 'format', 0);
 	},
 	toggleNormalFormat() {
-		this.isPlayerFullscreen() && this.exitFullscreen()
+		if (this.isPlayerFullscreen) {
+			this.exitFullscreen()
+		}
 
 		if (get(this, 'isNormal')) {
 			this.toggleFullscreenFormat()

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -62,6 +62,7 @@
 @import "components/logo";
 @import "components/map";
 @import "components/details";
+@import "components/channel-screen";
 
 // Major UI States or the UI
 @import "layout/root";

--- a/app/styles/components/_aside.scss
+++ b/app/styles/components/_aside.scss
@@ -70,7 +70,8 @@
 
 .Aside--right {
 	position: fixed;
-	z-index: 2;
+	// above main menu
+	z-index: 8;
 	top: auto;
 	right: 0;
 	bottom: 0;
@@ -79,13 +80,5 @@
 	.Root.is-minimized & {
 		width: auto;
 		height: auto;
-	}
-
-	.Root.is-maximized & {
-		top: 0;
-		right: 0;
-		width: 100%;
-		background-color: black;
-		z-index: 7;
 	}
 }

--- a/app/styles/components/_aside.scss
+++ b/app/styles/components/_aside.scss
@@ -70,8 +70,7 @@
 
 .Aside--right {
 	position: fixed;
-	// above main menu
-	z-index: 8;
+	z-index: 2;
 	top: auto;
 	right: 0;
 	bottom: 0;
@@ -80,5 +79,9 @@
 	.Root.is-minimized & {
 		width: auto;
 		height: auto;
+	}
+	.Root.is-maximized & {
+		// above menu
+		z-index: 8;
 	}
 }

--- a/app/styles/components/_channel-screen.scss
+++ b/app/styles/components/_channel-screen.scss
@@ -1,0 +1,27 @@
+.ChannelScreen {
+	// position element
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+
+	// position bg image
+	background-size: cover;
+	background-position: center;
+
+	// position content
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	.Btn {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+		opacity: 0;
+	}
+}

--- a/app/styles/components/_channel-screen.scss
+++ b/app/styles/components/_channel-screen.scss
@@ -6,9 +6,6 @@
 	bottom: 0;
 	left: 0;
 
-	// position bg image
-	background-size: cover;
-	background-position: center;
 
 	// position content
 	display: flex;
@@ -29,4 +26,16 @@
 			text-decoration: none;
 		}
 	}
+}
+
+.ChannelScreen-media {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	// position bg image
+	background-size: cover;
+	background-position: center;
+	filter: blur(1px);
 }

--- a/app/styles/components/_channel-screen.scss
+++ b/app/styles/components/_channel-screen.scss
@@ -37,5 +37,5 @@
 	// position bg image
 	background-size: cover;
 	background-position: center;
-	filter: blur(1px);
+	filter: blur(2px);
 }

--- a/app/styles/components/_channel-screen.scss
+++ b/app/styles/components/_channel-screen.scss
@@ -22,6 +22,11 @@
 		bottom: 0;
 		left: 0;
 		width: 100%;
-		opacity: 0;
+		// opacity: 0;
+		transition: opacity 500ms ease-in;
+		@include size-4;
+		&:hover {
+			text-decoration: none;
+		}
 	}
 }

--- a/app/styles/components/_input-autocomplete.scss
+++ b/app/styles/components/_input-autocomplete.scss
@@ -1,6 +1,6 @@
 .InputAutocomplete {
 	position: fixed;
-	z-index: 8;
+	z-index: 7;
 	top: 4.1rem;
 	left: 1rem;
 }

--- a/app/styles/components/_input-autocomplete.scss
+++ b/app/styles/components/_input-autocomplete.scss
@@ -1,6 +1,6 @@
 .InputAutocomplete {
 	position: fixed;
-	z-index: 2;
+	z-index: 8;
 	top: 4.1rem;
 	left: 1rem;
 }

--- a/app/styles/components/_playback.scss
+++ b/app/styles/components/_playback.scss
@@ -33,3 +33,18 @@ radio4000-player .Layout {
 radio4000-player .Btn {
 	min-height: initial;
 }
+
+// do not display the playback button:
+// - when on the docked route: linked version
+// - when the link is visible (so not active) hide the btn
+.Playback-dock.is-active,
+.Playback-dock:not(.is-active) + .Playback-dock {
+	display: none;
+}
+
+// only display the .Btn
+// .Root.is-docked {
+// 	.Btn.Playback-dock {
+// 		display: none;
+// 	}
+// }

--- a/app/styles/components/_playback.scss
+++ b/app/styles/components/_playback.scss
@@ -5,13 +5,10 @@
 }
 
 .Playback-layoutButtons {
-	position: absolute;
-	top: 0.3rem;
-	right: $sidebar-width;
 	z-index: 2;
 	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
+	flex-direction: row;
+	justify-content: flex-end;
 
 	> .Btn {
 		margin: 1px;

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -125,31 +125,33 @@
 		height: auto;
 	}
 	radio4000-player {
-		max-height: 80vh
+		max-height: 80vh;
+		& .Layout {
+			border-width: 0;
+		}
 	}
 }
 
 .Root.is-docked.is-withoutPlayer {
 	.ChannelScreen {
-		&::before {
-			content: "▶";
+		.Btn i {
+			border: 0.2rem solid $white;
 			background-color: $purple;
 			color: $white;
-			width: 5rem;
-			border-radius: 0.2rem;
-			height: 5rem;
-			text-align: center;
+			width: 2em;
+			height: 2em;
 			display: flex;
+			@include size-6;
 			justify-content: center;
 			align-items: center;
-			line-height: 0;
-			padding-left: 0.3rem;
-			font-size: 3rem;
-			border: 0.2rem solid $black;
-			box-shadow: 3px 4px 10px $white;
+			border-radius: 0.2rem;
+			box-shadow: 0.2rem 0.2rem 1.5rem $black;
+			transition: 300ms background-color ease-out;
 		}
-		&::before:hover {
-			border-color: $white;
+		.Btn.is-running i {
+			color: transparent;
+			background-color: transparent;
+			border-color: transparent;
 		}
 	}
 }

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -14,6 +14,7 @@
 		.SiteMain {
 			@media (min-width: $layout-m) {
 				margin-right: $sidebar-width;
+				padding-right: 1rem;
 			}
 		}
 		.Playback-layoutButtons {

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -35,14 +35,6 @@
 		}
 	}
 }
-.Root.is-minimized {
-	.Playback-minimize {
-		display: none;
-		@media (min-width: $layout-l) {
-			display: block;
-		}
-	}
-}
 
 /*
 	 Player is in minimized state
@@ -78,17 +70,14 @@
 		left: auto;
 	}
 
-	.Playback {
-		width: 200px;
-		height: 200px;
-	}
-
 	radio4000-player {
 		height: 200px !important;
+		min-height: auto !important;
 
 		.TrackList,
 		.Layout-header,
-		.Layout-footer {
+		.Layout-footer,
+		.Layout-main {
 			display: none;
 		}
 	}

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -152,6 +152,15 @@
 			color: transparent;
 			background-color: transparent;
 			border-color: transparent;
+			box-shadow: none;
+		}
+	}
+}
+
+.Root.is-docked.is-withPlayer {
+	.ChannelScreen {
+		.Btn {
+			display: none
 		}
 	}
 }

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -101,17 +101,28 @@
 
 .Root.is-docked.is-withPlayer {
 	flex-direction: column;
-	.Aside--right {
-		order: 0;
-		width: 100%;
-		padding-left: 5rem;
-		padding-right: 5rem;
-		padding-top: 1rem;
-		position: static;
-	}
 	.SiteMain {
 		order: 1;
 		margin-right: 0;
+		min-height: auto;
+	}
+	.Aside--right {
+		position: static;
+		order: 0;
+		width: 70vw;
+
+		// center with this, so the link under is clickable
+		margin-left: auto;
+		margin-right: auto;
+
+		min-height: 100vh;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+	.Playback {
+		flex-grow: 0;
+		height: auto;
 	}
 	radio4000-player {
 		max-height: 80vh

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -128,3 +128,28 @@
 		max-height: 80vh
 	}
 }
+
+.Root.is-docked.is-withoutPlayer {
+	.ChannelScreen {
+		&::before {
+			content: "▶";
+			background-color: $purple;
+			color: $white;
+			width: 5rem;
+			border-radius: 0.2rem;
+			height: 5rem;
+			text-align: center;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			line-height: 0;
+			padding-left: 0.3rem;
+			font-size: 3rem;
+			border: 0.2rem solid $black;
+			box-shadow: 3px 4px 10px $white;
+		}
+		&::before:hover {
+			border-color: $white;
+		}
+	}
+}

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -9,38 +9,65 @@
 	flex-direction: row;
 }
 
-.Root:not(.is-minimized).is-withPlayer .SiteMain {
-	margin-right: $sidebar-width;
-}
-
-/*
-	 Player is in maximized state
- */
-
-.Root.is-maximized {
-	radio4000-player {
-		height: 100vh;
-
-		.Layout {
-			border: 0;
+.Root.is-normal {
+	&.is-withPlayer {
+		.SiteMain {
+			@media (min-width: $layout-m) {
+				margin-right: $sidebar-width;
+			}
+		}
+		.Playback-layoutButtons {
+			position: absolute;
+			top: 0;
+			left: 0;
+			flex-direction: column;
+			transform: translateX(-100%);
 		}
 	}
+}
 
-	.Playback-layoutButtons {
-		flex-direction: row;
-		top: 0.2rem;
-		right: 0;
-		left: auto;
-	}
-
+.Root.is-maximized {
 	.Playback-fullscreen {
 		display: none;
-		order: 1;
 		@media (min-width: $layout-l) {
 			display: block;
 		}
 	}
 }
+.Root.is-minimized {
+	.Playback-minimize {
+		display: none;
+		@media (min-width: $layout-l) {
+			display: block;
+		}
+	}
+}
+
+/*
+	 Player is in minimized state
+ */
+.Root.is-maximized {
+	.Playback-layoutButtons {
+		position: absolute;
+		top: 0;
+		right: 0;
+	}
+	radio4000-player {
+		@media (min-width: $layout-m) {
+			@include size-2;
+		}
+		@media (min-width: $layout-ml) {
+			@include size-3;
+		}
+	}
+	radio4000-player .Layout {
+		border-width: 0;
+	}
+}
+
+/*
+	 Player is in minimized state
+ */
 
 .Root.is-minimized {
 	.Playback-layoutButtons {
@@ -64,19 +91,29 @@
 			display: none;
 		}
 	}
-
-	.Playback-minimize {
-		display: none;
-
-		@media (min-width: $layout-l) {
-			display: block;
-		}
-	}
 }
 
-// Hide the sidebar completely when we don't need it.
 .Root.is-withoutPlayer {
 	.Aside--right {
 		display: none;
+	}
+}
+
+.Root.is-docked.is-withPlayer {
+	flex-direction: column;
+	.Aside--right {
+		order: 0;
+		width: 100%;
+		padding-left: 5rem;
+		padding-right: 5rem;
+		padding-top: 1rem;
+		position: static;
+	}
+	.SiteMain {
+		order: 1;
+		margin-right: 0;
+	}
+	radio4000-player {
+		max-height: 80vh
 	}
 }

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -81,6 +81,12 @@
 			display: none;
 		}
 	}
+	.Playback-minimize {
+		display: none;
+		@media (min-width: $layout-l) {
+			display: block;
+		}
+	}
 }
 
 .Root.is-withoutPlayer {

--- a/tests/unit/channel/player/controller-test.js
+++ b/tests/unit/channel/player/controller-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | channel/player', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:channel/player');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/channel/player/route-test.js
+++ b/tests/unit/channel/player/route-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | channel/player', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:channel/player');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
- improve fullscreen mode by using the browser's fullscreen. It allows us to have on mobile and desktop a better experience since the browser's URL bar is hidden, and only the radio4000-player (Aside--right, to have the r4-cms layout controls) is displayed fullscreen.
- add a new mode, docked, at /channel/player.
It shows the channel cover image in fullscreen, a play button, then the player displayed in the DOM (static, docked). The UX should favor movements between modes.