### PR TITLE
add /:channel/tags

### DIFF
--- a/app/channel/tags/route.js
+++ b/app/channel/tags/route.js
@@ -1,0 +1,19 @@
+import Route from '@ember/routing/route'
+import { generateUniqueHashtags } from '../../utils/hashtag'
+
+export default Route.extend({
+	model() {
+		const channel = this.modelFor('channel')
+		return this.store.query('track', {
+			orderBy: 'channel',
+			equalTo: channel.id
+		}).then(tracks => {
+			const tags = generateUniqueHashtags(tracks)
+			return {
+				channel,
+				tracks,
+				tags
+			}
+		})
+	}
+})

--- a/app/channel/tags/route.js
+++ b/app/channel/tags/route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route'
-import { generateUniqueHashtags } from '../../utils/hashtag'
+import { generateUniqueHashtags } from 'radio4000/utils/hashtag'
 
 export default Route.extend({
 	model() {

--- a/app/channel/tags/template.hbs
+++ b/app/channel/tags/template.hbs
@@ -1,7 +1,20 @@
 <section class="Section">
 	<div class="Container Container--large">
+		<h2>Selected tags</h2>
+		{{channel-tags
+				tags=model.channel.selectedHashtags
+				channel=model.channel
+		}}
+	</div>
+</section>
+
+<section class="Section">
+	<div class="Container Container--large">
 		<h2>All tags</h2>
-		{{channel-tags tags=model.tags channel=model.channel}}
+		{{channel-tags
+				tags=model.tags.tags
+				channel=model.channel
+		}}
 	</div>
 </section>
 

--- a/app/channel/tags/template.hbs
+++ b/app/channel/tags/template.hbs
@@ -1,18 +1,17 @@
 <section class="Section">
 	<div class="Container Container--large">
-		<nav class="Tags">
-			{{#each model.tags.tags as |item|}}
-				{{#link-to
-						 "channel.tracks"
-						 model.channel
-						 (query-params search=item)
-						 class="Tag-item"
-				}}
-					{{item}}
-				{{/link-to}}
-			{{/each}}
-		</nav>
+		<h2>All tags</h2>
+		{{channel-tags tags=model.tags channel=model.channel}}
 	</div>
 </section>
+
+{{#if model.canEdit}}
+	<section class="Section">
+		<div class="Container Container--large">
+			<h2>Tracks without tag</h2>
+			{{tracks-without-tag tracks=model.tracks}}
+		</div>
+	</section>
+{{/if}}
 
 {{outlet}}

--- a/app/channel/tags/template.hbs
+++ b/app/channel/tags/template.hbs
@@ -1,0 +1,18 @@
+<section class="Section">
+	<div class="Container Container--large">
+		<nav class="Tags">
+			{{#each model.tags.tags as |item|}}
+				{{#link-to
+						 "channel.tracks"
+						 model.channel
+						 (query-params search=item)
+						 class="Tag-item"
+				}}
+					{{item}}
+				{{/link-to}}
+			{{/each}}
+		</nav>
+	</div>
+</section>
+
+{{outlet}}

--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -17,12 +17,14 @@
 					title="All tracks [⌨ g t]"}}
 					Tracks <span class="Muted">({{model.totalTracks}})</span>
 				{{/link-to}}
-				{{#link-to
-						 'channel.tags'
-						 class="Tabs-item"
-						 title="Tags from this radio's tracks [⌨ g #]"}}
-					Tags
-				{{/link-to}}
+				{{#if model.selectedHashtags}}
+					{{#link-to
+							 'channel.tags'
+							 class="Tabs-item"
+							 title="Tags from this radio's tracks [⌨ g #]"}}
+						Tags
+					{{/link-to}}
+				{{/if}}
 				{{#link-to
 					'channel.favorites'
 					class="Tabs-item"

--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -18,6 +18,12 @@
 					Tracks <span class="Muted">({{model.totalTracks}})</span>
 				{{/link-to}}
 				{{#link-to
+						 'channel.tags'
+						 class="Tabs-item"
+						 title="Tags from this radio's tracks [⌨ g #]"}}
+					Tags
+				{{/link-to}}
+				{{#link-to
 					'channel.favorites'
 					class="Tabs-item"
 					title="Favorites of this radio [⌨ g f]"}}

--- a/app/components/channel-tags/component.js
+++ b/app/components/channel-tags/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/channel-tags/template.hbs
+++ b/app/components/channel-tags/template.hbs
@@ -1,6 +1,6 @@
 <nav class="Tags">
-	{{#if tags.tags}}
-		{{#each tags.tags as |item|}}
+	{{#if tags}}
+		{{#each tags as |item|}}
 			{{#link-to
 					 "channel.tracks"
 					 channel

--- a/app/components/channel-tags/template.hbs
+++ b/app/components/channel-tags/template.hbs
@@ -11,6 +11,6 @@
 			{{/link-to}}
 		{{/each}}
 		{{else}}
-		<p>There are no tags yet</p>
+		<p>There are no tags yet.</p>
 	{{/if}}
 </nav>

--- a/app/components/channel-tags/template.hbs
+++ b/app/components/channel-tags/template.hbs
@@ -1,0 +1,16 @@
+<nav class="Tags">
+	{{#if tags.tags}}
+		{{#each tags.tags as |item|}}
+			{{#link-to
+					 "channel.tracks"
+					 channel
+					 (query-params search=(concat "#" item))
+					 class="Tag-item"
+			}}
+				{{item}}
+			{{/link-to}}
+		{{/each}}
+		{{else}}
+		<p>There are no tags yet</p>
+	{{/if}}
+</nav>

--- a/app/components/tracks-without-tag/component.js
+++ b/app/components/tracks-without-tag/component.js
@@ -3,9 +3,14 @@ import {get, computed} from '@ember/object';
 
 export default Component.extend({
 	tracksWithoutTag: computed('tracks', function() {
-		return get(this, 'tracks').filter(i => {
+		const tracks = get(this, 'tracks')
+
+		if (!tracks) return []
+
+		return tracks.filter(i => {
 			const t = get(i, 'tags')
 			if (!t) return true
+			return false
 		})
 	})
 });

--- a/app/components/tracks-without-tag/component.js
+++ b/app/components/tracks-without-tag/component.js
@@ -1,0 +1,11 @@
+import Component from '@ember/component';
+import {get, computed} from '@ember/object';
+
+export default Component.extend({
+	tracksWithoutTag: computed('tracks', function() {
+		return get(this, 'tracks').filter(i => {
+			const t = get(i, 'tags')
+			if (!t) return true
+		})
+	})
+});

--- a/app/components/tracks-without-tag/template.hbs
+++ b/app/components/tracks-without-tag/template.hbs
@@ -1,0 +1,18 @@
+{{#if tracksWithoutTag.length}}
+
+	{{#tracks-list
+			 keyboardActivated=true
+			 items=tracksWithoutTag
+			 grouped=false
+			 search=false
+			 searchQuery=search
+			 locate=locate
+			 as |item|
+	}}
+		{{track-item track=item}}
+	{{/tracks-list}}
+{{else}}
+	<p>No track is without tag.</p>
+{{/if}}
+
+{{yield}}

--- a/app/helpers/link-hashtags.js
+++ b/app/helpers/link-hashtags.js
@@ -1,9 +1,7 @@
 import Ember from 'ember'
 import {helper} from '@ember/component/helper'
 import {htmlSafe, isHTMLSafe} from '@ember/string'
-
-// https://regex101.com/r/pJ4wC5/1
-const hashtagRegex = /(^|\s)(#[a-z\d-]+)/ig
+import {hashtagRegex} from '../utils/hashtag'
 
 export function linkHashtags([string, slug]) {
 	if (!slug) {

--- a/app/helpers/link-hashtags.js
+++ b/app/helpers/link-hashtags.js
@@ -1,7 +1,7 @@
 import Ember from 'ember'
 import {helper} from '@ember/component/helper'
 import {htmlSafe, isHTMLSafe} from '@ember/string'
-import {hashtagRegex} from '../utils/hashtag'
+import {hashtagRegex} from 'radio4000/utils/hashtag'
 
 export function linkHashtags([string, slug]) {
 	if (!slug) {

--- a/app/models/channel.js
+++ b/app/models/channel.js
@@ -1,11 +1,12 @@
-import Ember from 'ember';
-import DS from 'ember-data';
-import firebase from 'firebase';
-import {task} from 'ember-concurrency';
-import {and, hash} from 'ember-awesome-macros';
-import {validator, buildValidations} from 'ember-cp-validations';
-import channelConst from 'radio4000/utils/channel-const';
-import toggleObject from 'radio4000/utils/toggle-object';
+import Ember from 'ember'
+import DS from 'ember-data'
+import firebase from 'firebase'
+import {task} from 'ember-concurrency'
+import {and, hash} from 'ember-awesome-macros'
+import {validator, buildValidations} from 'ember-cp-validations'
+import channelConst from 'radio4000/utils/channel-const'
+import toggleObject from 'radio4000/utils/toggle-object'
+import {findHashtags} from 'radio4000/utils/hashtag'
 
 const {attr, hasMany, belongsTo} = DS;
 const {computed, inject, get} = Ember;
@@ -96,6 +97,10 @@ export default DS.Model.extend(Validations, {
 
 	totalTracks: computed('tracks.[]', function () {
 		return this.hasMany('tracks').ids().length;
+	}),
+
+	selectedHashtags: computed('body', function () {
+		return findHashtags(get(this, 'body'))
 	}),
 
 	hasFewTracks: computed.lte('totalTracks', 2),

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -6,6 +6,11 @@ import {validator, buildValidations} from 'ember-cp-validations';
 import youtubeUrlToId from 'radio4000/utils/youtube-url-to-id';
 import {fetchTrackAvailability} from 'radio4000/utils/youtube-api';
 import format from 'date-fns/format';
+import {
+	hashtagRegex,
+	generateHastags,
+	findHashtags
+} from '../utils/hashtag'
 
 const {Model, attr, belongsTo} = DS;
 const {get, set, computed} = Ember;
@@ -79,6 +84,12 @@ export default Model.extend(Validations, {
 		}
 
 		return format(created, 'MMMM YYYY');
+	}),
+
+	tags: computed('body', function() {
+		const body = get(this, 'body')
+		const tags = findHashtags(body)
+		return tags
 	}),
 
 	searchableData: computed('title', 'body', function() {

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -6,11 +6,7 @@ import {validator, buildValidations} from 'ember-cp-validations';
 import youtubeUrlToId from 'radio4000/utils/youtube-url-to-id';
 import {fetchTrackAvailability} from 'radio4000/utils/youtube-api';
 import format from 'date-fns/format';
-import {
-	hashtagRegex,
-	generateHastags,
-	findHashtags
-} from '../utils/hashtag'
+import {findHashtags} from '../utils/hashtag'
 
 const {Model, attr, belongsTo} = DS;
 const {get, set, computed} = Ember;

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -6,7 +6,7 @@ import {validator, buildValidations} from 'ember-cp-validations';
 import youtubeUrlToId from 'radio4000/utils/youtube-url-to-id';
 import {fetchTrackAvailability} from 'radio4000/utils/youtube-api';
 import format from 'date-fns/format';
-import {findHashtags} from '../utils/hashtag'
+import {findHashtags} from 'radio4000/utils/hashtag'
 
 const {Model, attr, belongsTo} = DS;
 const {get, set, computed} = Ember;

--- a/app/router.js
+++ b/app/router.js
@@ -3,70 +3,70 @@ import EmberRouter from '@ember/routing/router'
 import config from './config/environment'
 
 const Router = EmberRouter.extend({
-    location: config.locationType,
-    rootURL: config.rootURL
+	location: config.locationType,
+	rootURL: config.rootURL
 })
 
 Router.map(function() {
-    this.route('channels', {path: '/'}, function() {
-        this.route('all')
-        this.route('history')
-        this.route('map')
-        this.route('new')
-        this.route('search')
-        this.route('explore')
-    })
-    this.route('channel', {path: '/:channel_slug'}, function() {
-      this.route('index', {path: '/'})
-      this.route('home')
-      this.route('deprecated-track', {path: ':track_id'})
-      this.route('tracks', function() {
-          this.route('track', {path: ':track_id'}, function() {
-              this.route('index', {path: '/'})
-          })
-      })
-      this.route('add')
-      this.route('edit')
-      this.route('delete')
-      this.route('favorites')
-      this.route('followers')
-      this.route('play', function() {
-          this.route('random')
-      })
-      this.route('player');
-      this.route('tags');
-    })
-    this.authenticatedRoute('add')
-    this.authenticatedRoute('bookmarklet')
-    this.route('about', function() {
-        this.route('intro', {path: '/'})
-        this.route('contact')
-    })
-    this.route('feedback')
-    this.route('auth', function() {
-        this.route('signup')
-        this.route('login')
-        this.route('logout', {path: '/logout'})
-    })
-    this.route('styleguide', function() {
-        this.route('typography')
-        this.route('colors')
-        this.route('forms')
-        this.route('tabs')
-        this.route('buttons')
-    })
-    this.route('404')
-    this.authenticatedRoute('settings', function() {
-        this.route('channel', function() {
-            this.route('image')
-            this.route('backup')
-            this.route('delete')
-            this.route('map')
-        })
-        this.route('account')
-    })
-    this.authenticatedRoute('premium')
-    this.route('menu');
+		this.route('channels', {path: '/'}, function() {
+				this.route('all')
+				this.route('history')
+				this.route('map')
+				this.route('new')
+				this.route('search')
+				this.route('explore')
+		})
+		this.route('channel', {path: '/:channel_slug'}, function() {
+			this.route('index', {path: '/'})
+			this.route('home')
+			this.route('deprecated-track', {path: ':track_id'})
+			this.route('tracks', function() {
+					this.route('track', {path: ':track_id'}, function() {
+							this.route('index', {path: '/'})
+					})
+			})
+			this.route('add')
+			this.route('edit')
+			this.route('delete')
+			this.route('favorites')
+			this.route('followers')
+			this.route('play', function() {
+					this.route('random')
+			})
+			this.route('player');
+			this.route('tags');
+		})
+		this.authenticatedRoute('add')
+		this.authenticatedRoute('bookmarklet')
+		this.route('about', function() {
+				this.route('intro', {path: '/'})
+				this.route('contact')
+		})
+		this.route('feedback')
+		this.route('auth', function() {
+				this.route('signup')
+				this.route('login')
+				this.route('logout', {path: '/logout'})
+		})
+		this.route('styleguide', function() {
+				this.route('typography')
+				this.route('colors')
+				this.route('forms')
+				this.route('tabs')
+				this.route('buttons')
+		})
+		this.route('404')
+		this.authenticatedRoute('settings', function() {
+				this.route('channel', function() {
+						this.route('image')
+						this.route('backup')
+						this.route('delete')
+						this.route('map')
+				})
+				this.route('account')
+		})
+		this.authenticatedRoute('premium')
+		this.route('menu');
 })
 
 export default Router

--- a/app/router.js
+++ b/app/router.js
@@ -3,69 +3,70 @@ import EmberRouter from '@ember/routing/router'
 import config from './config/environment'
 
 const Router = EmberRouter.extend({
-	location: config.locationType,
-	rootURL: config.rootURL
+    location: config.locationType,
+    rootURL: config.rootURL
 })
 
 Router.map(function() {
-	this.route('channels', {path: '/'}, function() {
-		this.route('all')
-		this.route('history')
-		this.route('map')
-		this.route('new')
-		this.route('search')
-		this.route('explore')
-	})
-	this.route('channel', {path: '/:channel_slug'}, function() {
-		this.route('index', {path: '/'})
-		this.route('home')
-		this.route('deprecated-track', {path: ':track_id'})
-		this.route('tracks', function() {
-			this.route('track', {path: ':track_id'}, function() {
-				this.route('index', {path: '/'})
-			})
-		})
-		this.route('add')
-		this.route('edit')
-		this.route('delete')
-		this.route('favorites')
-		this.route('followers')
-		this.route('play', function() {
-			this.route('random')
-		})
-		this.route('player');
-	})
-	this.authenticatedRoute('add')
-	this.authenticatedRoute('bookmarklet')
-	this.route('about', function() {
-		this.route('intro', {path: '/'})
-		this.route('contact')
-	})
-	this.route('feedback')
-	this.route('auth', function() {
-		this.route('signup')
-		this.route('login')
-		this.route('logout', {path: '/logout'})
-	})
-	this.route('styleguide', function() {
-		this.route('typography')
-		this.route('colors')
-		this.route('forms')
-		this.route('tabs')
-		this.route('buttons')
-	})
-	this.route('404')
-	this.authenticatedRoute('settings', function() {
-		this.route('channel', function() {
-			this.route('image')
-			this.route('backup')
-			this.route('delete')
-			this.route('map')
-		})
-		this.route('account')
-	})
-	this.authenticatedRoute('premium')
-	this.route('menu');
+    this.route('channels', {path: '/'}, function() {
+        this.route('all')
+        this.route('history')
+        this.route('map')
+        this.route('new')
+        this.route('search')
+        this.route('explore')
+    })
+    this.route('channel', {path: '/:channel_slug'}, function() {
+      this.route('index', {path: '/'})
+      this.route('home')
+      this.route('deprecated-track', {path: ':track_id'})
+      this.route('tracks', function() {
+          this.route('track', {path: ':track_id'}, function() {
+              this.route('index', {path: '/'})
+          })
+      })
+      this.route('add')
+      this.route('edit')
+      this.route('delete')
+      this.route('favorites')
+      this.route('followers')
+      this.route('play', function() {
+          this.route('random')
+      })
+      this.route('player');
+      this.route('tags');
+    })
+    this.authenticatedRoute('add')
+    this.authenticatedRoute('bookmarklet')
+    this.route('about', function() {
+        this.route('intro', {path: '/'})
+        this.route('contact')
+    })
+    this.route('feedback')
+    this.route('auth', function() {
+        this.route('signup')
+        this.route('login')
+        this.route('logout', {path: '/logout'})
+    })
+    this.route('styleguide', function() {
+        this.route('typography')
+        this.route('colors')
+        this.route('forms')
+        this.route('tabs')
+        this.route('buttons')
+    })
+    this.route('404')
+    this.authenticatedRoute('settings', function() {
+        this.route('channel', function() {
+            this.route('image')
+            this.route('backup')
+            this.route('delete')
+            this.route('map')
+        })
+        this.route('account')
+    })
+    this.authenticatedRoute('premium')
+    this.route('menu');
 })
 
 export default Router

--- a/app/styles/components/_tags.scss
+++ b/app/styles/components/_tags.scss
@@ -2,33 +2,10 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-
-	label {
-		margin-right: 0.5em;
-	}
-
-	button + label {
-		margin-left: 0.5em;
-	}
 }
-
-.Tags--vertical {
-	flex-direction: column;
-
-	label {
-		margin-right: 0;
-		margin-bottom: 0.5em;
-	}
-
-	button + label {
-		margin-left: 0;
-		margin-bottom: 0.5em;
-	}
-}
-
-.Tag {
+.Tag-item {
+	padding: 0.4rem;
+	margin: 0.1rem;
 	background-color: $slightgray;
-	padding: 0.5rem;
-	margin: 0.2rem;
-	margin-right: 0.6rem;
+	text-decoration: none;
 }

--- a/app/utils/hashtag.js
+++ b/app/utils/hashtag.js
@@ -30,6 +30,8 @@ const generateHashtags = (items, attribute = 'body') => {
 const generateUniqueHashtags = (items, attribute) => {
 	let tags = generateHashtags(items, attribute)
 
+	if (!tags) return null
+
 	let uniqueTags = tags.reduce((acc, cur) => {
 		if (Object.prototype.hasOwnProperty.call(acc, cur)) {
 			acc[cur]++

--- a/app/utils/hashtag.js
+++ b/app/utils/hashtag.js
@@ -6,11 +6,10 @@ const findHashtags = searchText => {
 	// https://regexr.com/46r2p
 	var regexp = /(?:\B#)(\w|-?)+\b/g
 	let result = searchText.match(regexp)
-	if (result) {
-		return result.map(item => item.replace('#',''))
-	} else {
+	if (!result) {
 		return null
 	}
+	return result.map(item => item.replace('#', ''))
 }
 
 const generateHashtags = (items, attribute = 'body') => {
@@ -29,10 +28,10 @@ const generateHashtags = (items, attribute = 'body') => {
 }
 
 const generateUniqueHashtags = (items, attribute) => {
-	let tags = generateHashtags(items)
+	let tags = generateHashtags(items, attribute)
 
 	let uniqueTags = tags.reduce((acc, cur) => {
-		if(acc.hasOwnProperty(cur)) {
+		if (Object.prototype.hasOwnProperty.call(acc, cur)) {
 			acc[cur]++
 		} else {
 			acc[cur] = 1
@@ -48,8 +47,6 @@ const generateUniqueHashtags = (items, attribute) => {
 		tags: sortedTags.map(i => i[0]),
 		sortedTags: sortedTags
 	}
-
-	console.log('result', result)
 
 	return result
 }

--- a/app/utils/hashtag.js
+++ b/app/utils/hashtag.js
@@ -1,0 +1,62 @@
+// https://regex101.com/r/pJ4wC5/1
+const hashtagRegex = /(^|\s)(#[a-z\d-]+)/ig
+
+const findHashtags = searchText => {
+	if (!searchText) return null
+	// https://regexr.com/46r2p
+	var regexp = /(?:\B#)(\w|-?)+\b/g
+	let result = searchText.match(regexp)
+	if (result) {
+		return result.map(item => item.replace('#',''))
+	} else {
+		return null
+	}
+}
+
+const generateHashtags = (items, attribute = 'body') => {
+	let aggBodies
+	if (items && items.length) {
+		aggBodies = items
+			.map(item => item[attribute])
+			.reduce((acc, curr) => {
+				return acc + ' ' + curr
+			})
+	} else {
+		aggBodies = ''
+	}
+
+	return findHashtags(aggBodies)
+}
+
+const generateUniqueHashtags = (items, attribute) => {
+	let tags = generateHashtags(items)
+
+	let uniqueTags = tags.reduce((acc, cur) => {
+		if(acc.hasOwnProperty(cur)) {
+			acc[cur]++
+		} else {
+			acc[cur] = 1
+		}
+		return acc
+	}, {})
+
+	let sortedTags = Object.entries(uniqueTags).sort((a, b) => {
+		return b[1] - a[1]
+	})
+
+	const result = {
+		tags: sortedTags.map(i => i[0]),
+		sortedTags: sortedTags
+	}
+
+	console.log('result', result)
+
+	return result
+}
+
+export {
+	hashtagRegex,
+	generateHashtags,
+	generateUniqueHashtags,
+	findHashtags
+}

--- a/tests/integration/components/channel-tags/component-test.js
+++ b/tests/integration/components/channel-tags/component-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | channel-tags', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{channel-tags}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#channel-tags}}
+        template block text
+      {{/channel-tags}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/integration/components/channel-tags/component-test.js
+++ b/tests/integration/components/channel-tags/component-test.js
@@ -12,15 +12,6 @@ module('Integration | Component | channel-tags', function(hooks) {
 
     await render(hbs`{{channel-tags}}`);
 
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      {{#channel-tags}}
-        template block text
-      {{/channel-tags}}
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.equal(this.element.textContent.trim(), 'There are no tags yet.');
   });
 });

--- a/tests/integration/components/tracks-without-tag/component-test.js
+++ b/tests/integration/components/tracks-without-tag/component-test.js
@@ -12,15 +12,6 @@ module('Integration | Component | tracks-without-tag', function(hooks) {
 
     await render(hbs`{{tracks-without-tag}}`);
 
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      {{#tracks-without-tag}}
-        template block text
-      {{/tracks-without-tag}}
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.equal(this.element.textContent.trim(), 'No track is without tag.');
   });
 });

--- a/tests/integration/components/tracks-without-tag/component-test.js
+++ b/tests/integration/components/tracks-without-tag/component-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | tracks-without-tag', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{tracks-without-tag}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#tracks-without-tag}}
+        template block text
+      {{/tracks-without-tag}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/unit/channel/tags/route-test.js
+++ b/tests/unit/channel/tags/route-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | channel/tags', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:channel/tags');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
List all tags and order them by popularity, most occurrences first.

- track model now have a computed property `track.tags`
- add a `/channel/tags` route
- list selected tags, those in the channel.body
- list tracks with no tags, so it is easier to start editing 

What we can think about in the future:
- show how many tracks are in a `tag`; ex: `house (200)`
- should the tags link display all tags on the tags page, or continue linking to `/:channel/tracks?search=#tag`
- where to list all tracks without discogs
- where to list all tracks with broken media links
- how to *mass edit* multiple tracks at once, add tags. remove tags, clean things up
- how to rename a tag; ex: rename `#PM` to `#pm`