### PR TITLE
Feat/channels inputs styles

### DIFF
--- a/app/channels/explore/template.hbs
+++ b/app/channels/explore/template.hbs
@@ -13,7 +13,7 @@
 						<span class="Label-title">
 							Search
 						</span>
-						{{#jets-search-focus}}
+						{{#jets-search-focus class="Label-inputContainer"}}
 							{{jets-search
 									contentTag=".JetsSearchContainer"
 									content=filteredChannels

--- a/app/styles/base/_form.scss
+++ b/app/styles/base/_form.scss
@@ -179,10 +179,14 @@ progress {
 // labels
 .Label--horizontal {
 	display: flex;
+	flex-grow: 1;
 	align-items: center;
 	.Label-title {
 		padding-right: 0.5rem;
 	}
+}
+.Label-inputContainer {
+	flex-grow: 1;
 }
 
 

--- a/app/styles/components/_button-group.scss
+++ b/app/styles/components/_button-group.scss
@@ -1,5 +1,6 @@
 .BtnGroup {
 	display: flex;
+	flex-grow: 1;
 	flex-shrink: 0;
 	flex-flow: row wrap;
 	align-items: center;

--- a/app/styles/components/_button-group.scss
+++ b/app/styles/components/_button-group.scss
@@ -10,6 +10,9 @@
 	.BtnGroups & {
 		margin-bottom: 0.4rem;
 	}
+	.BtnGroups &:last-child {
+		flex-grow: 0;
+	}
 }
 
 .BtnGroup--vertical {


### PR DESCRIPTION
Makes:
- the search input on /explore, be full with on mobile
- the last `.ButtonGroup` be at the end of the container on mobile, horizontally