### PR TITLE
Show YouTube volume button longer

### DIFF
--- a/app/styles/base/_config.scss
+++ b/app/styles/base/_config.scss
@@ -92,4 +92,4 @@ $border-radius: 3px;
 $bar-height: 50px;
 $bar-border-size: 2px;
 $progress-height: 10px;
-$sidebar-width: 20rem;
+$sidebar-width: 21rem;


### PR DESCRIPTION
We got a comment in the feedback form that the YouTube volume button isn't visible. 

I checked and the thing is that YouTube hides it below certain sizes. On my Firefox desktop, the volume button disappears below 1000px. BUT, if I change the "player sidebar" from 20 to 21rem, it stays all the way to mobile.

