### PR TITLE
fix main-menu to bottom right, and dock player to the top on mobile

### DIFF
--- a/app/channels/template.hbs
+++ b/app/channels/template.hbs
@@ -1,6 +1,6 @@
 <div class="Sections">
 	<div class="Section">
-		<nav class="Container Container--first Container--contentCentered Container--full">
+		<nav class="Container Container--contentCentered Container--full">
 			{{aside-channels
 				userChannel=session.currentUser.channels.firstObject}}
 		</nav>

--- a/app/styles/base/_button.scss
+++ b/app/styles/base/_button.scss
@@ -277,7 +277,7 @@
 
 .Btn--navigationToggle {
 	position: fixed;
-	top: 1rem;
+	bottom: 1rem;
 	left: 1rem;
 	z-index: 7;
 

--- a/app/styles/base/_button.scss
+++ b/app/styles/base/_button.scss
@@ -278,7 +278,7 @@
 .Btn--navigationToggle {
 	position: fixed;
 	bottom: 1rem;
-	left: 1rem;
+	left: 0.5rem;
 	z-index: 7;
 
 	display: block;

--- a/app/styles/components/_aside.scss
+++ b/app/styles/components/_aside.scss
@@ -36,6 +36,20 @@
 	.Root.is-minimized & {
 		width: auto;
 		height: auto;
+		position: sticky;
+		margin-top: 0.1rem;
+		order: 0;
+		top: 0;
+		right: 0;
+		left: 0;
+
+		@media (min-width: $layout-xl) {
+			position: fixed;
+			right: 0;
+			bottom: 0;
+			top: auto;
+			left: auto;
+		}
 	}
 	.Root.is-maximized & {
 		// above menu

--- a/app/styles/components/_input-autocomplete.scss
+++ b/app/styles/components/_input-autocomplete.scss
@@ -1,7 +1,7 @@
 .InputAutocomplete {
 	position: fixed;
 	z-index: 7;
-	top: 4.1rem;
+	bottom: 3.5rem;
 	left: 1rem;
 }
 
@@ -55,6 +55,8 @@
 
 .aa-dropdown-menu {
 	margin-top: -1px;
+	bottom: 100%;
+	top: auto !important;
 	width: 100%;
 	background-color: $superlightgray;
 	box-shadow: $box-shadow-large;

--- a/app/styles/components/_input-autocomplete.scss
+++ b/app/styles/components/_input-autocomplete.scss
@@ -2,7 +2,7 @@
 	position: fixed;
 	z-index: 7;
 	bottom: 3.5rem;
-	left: 1rem;
+	left: 0.5rem;
 }
 
 .aa-container {

--- a/app/styles/components/_playback.scss
+++ b/app/styles/components/_playback.scss
@@ -16,6 +16,10 @@
 	}
 }
 
+.Playback-player {
+	flex-grow: 1;
+}
+
 /**
  * The external player used inside .Playback
  */
@@ -43,8 +47,17 @@ radio4000-player .Btn {
 }
 
 // only display the .Btn
-// .Root.is-docked {
-// 	.Btn.Playback-dock {
-// 		display: none;
-// 	}
-// }
+.Root.is-minimized {
+	.Playback {
+		display: flex;
+		flex-direction: column;
+	}
+	.Playback-layoutButtons {
+		order: 1;
+		display: flex;
+		flex-direction: row;
+		@media (min-width: $layout-xl) {
+			order: 0;
+		}
+	}
+}

--- a/app/styles/layout/_container.scss
+++ b/app/styles/layout/_container.scss
@@ -68,7 +68,3 @@
 		padding-right: 0;
 	}
 }
-
-.Container--first {
-	padding-left: 4rem;
-}

--- a/app/styles/layout/_layout.scss
+++ b/app/styles/layout/_layout.scss
@@ -27,7 +27,6 @@ body {
  */
 .SiteMain {
 	display: flex;
-	min-height: 100vh;
 	width: 100%;
 	flex: 2;
 	overflow-x: hidden;
@@ -35,4 +34,13 @@ body {
 
 .overflow-x-auto {
 	overflow-x: auto;
+}
+
+.SiteHeader {
+	position: sticky;
+	top: 0;
+	display: flex;
+	flex-direction: row;
+	padding: 0.5rem;
+	justify-content: space-between;
 }

--- a/app/styles/layout/_root.scss
+++ b/app/styles/layout/_root.scss
@@ -7,6 +7,7 @@
 	display: flex;
 	flex-wrap: nowrap;
 	flex-direction: row;
+	min-height: 100vh;
 }
 
 .Root.is-normal {
@@ -63,11 +64,10 @@
  */
 
 .Root.is-minimized {
-	.Playback-layoutButtons {
-		flex-direction: row;
-		top: -2.3rem;
-		right: 0;
-		left: auto;
+	flex-direction: column;
+
+	.SiteMain {
+		order: 1;
 	}
 
 	radio4000-player {

--- a/app/styles/layout/_sections.scss
+++ b/app/styles/layout/_sections.scss
@@ -11,11 +11,13 @@
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
-	padding-top: 2rem;
+	padding-top: 1rem;
+	@media (min-width: $layout-xl) {
+		padding-top: 2rem;
+	}
 }
 
 .Sections--center {
-	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;


### PR DESCRIPTION
- main search and main nav btn top the bottom left
- dock the player to the top sticky, when on mobile/tablet

The objective is to solve the issues with the player being over the interface on mobile.
Also I feel it could be nicer on mobile when browsing the page.

To me this is an experiment I'd like to try live, and see how this feels by real usage.