### PR TITLE
fix issue when youtube quota have been used

### DIFF
--- a/app/utils/youtube-api.js
+++ b/app/utils/youtube-api.js
@@ -36,7 +36,10 @@ const fetchTrackAvailability = async function (ytid) {
 	// let data = await fetchYoutubeTrack(ytid, 'items(id,status)&part=status')
 	let data = await fetchYoutubeTrack(ytid, 'items(id,snippet(title))&part=snippet')
 
-	return Boolean(data.items.length)
+	if (!data.error) {
+		return Boolean(data.items.length)
+	}
+	return true
 }
 
 export {fetchTitle, fetchTrackAvailability};


### PR DESCRIPTION
fix for when youtube quotas are not working, we can't check track availability, therefore just allow